### PR TITLE
GLMCount + probabilistic output

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -19,41 +19,17 @@ git-tree-sha1 = "055eb2690182ebc31087859c3dd8598371d3ef9e"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.3"
 
-[[CSV]]
-deps = ["CategoricalArrays", "DataFrames", "DataStreams", "Dates", "Mmap", "Parsers", "Profile", "Random", "Tables", "Test", "Unicode", "WeakRefStrings"]
-git-tree-sha1 = "b92c6f626a044cc9619156d54994b94084d40abe"
-uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-version = "0.4.3"
-
 [[CategoricalArrays]]
 deps = ["Compat", "Future", "Missings", "Printf", "Reexport", "Requires"]
 git-tree-sha1 = "94d16e77dfacc59f6d6c1361866906dbb65b6f6b"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 version = "0.5.2"
 
-[[CodecZlib]]
-deps = ["BinaryProvider", "Libdl", "Test", "TranscodingStreams"]
-git-tree-sha1 = "e3df104c84dfc108f0ca203fd7f5bbdc98641ae9"
-uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.5.1"
-
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
 git-tree-sha1 = "49269e311ffe11ac5b334681d212329002a9832a"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "1.5.1"
-
-[[DataFrames]]
-deps = ["CategoricalArrays", "CodecZlib", "Compat", "DataStreams", "Dates", "InteractiveUtils", "IteratorInterfaceExtensions", "LinearAlgebra", "Missings", "Printf", "Random", "Reexport", "SortingAlgorithms", "Statistics", "StatsBase", "TableTraits", "Tables", "Test", "TranscodingStreams", "Unicode", "WeakRefStrings"]
-git-tree-sha1 = "af5c8a233b838076947ef0c8f882f732ad578112"
-uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.17.0"
-
-[[DataStreams]]
-deps = ["Dates", "Missings", "Test", "WeakRefStrings"]
-git-tree-sha1 = "69c72a1beb4fc79490c361635664e13c8e4a9548"
-uuid = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
-version = "0.4.1"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
@@ -85,9 +61,6 @@ git-tree-sha1 = "c24e9b6500c037673f0241a2783472b8c3d080c7"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 version = "0.16.4"
 
-[[FileWatching]]
-uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
-
 [[Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
@@ -114,14 +87,6 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
-
-[[MLJ]]
-deps = ["CSV", "CategoricalArrays", "DataFrames", "Dates", "Distances", "Distributed", "Distributions", "LinearAlgebra", "MLJBase", "MLJRegistry", "MultivariateStats", "ProgressMeter", "Random", "Requires", "Revise", "Statistics", "StatsBase", "TOML", "Tables"]
-git-tree-sha1 = "e539ab1c5109dc7b0252f6e5447a602f76fae183"
-repo-rev = "master"
-repo-url = "https://github.com/alan-turing-institute/MLJ.jl"
-uuid = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
-version = "0.1.0"
 
 [[MLJBase]]
 deps = ["CategoricalArrays", "Distributions", "Statistics", "Tables"]
@@ -152,12 +117,6 @@ version = "0.4.0"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[MultivariateStats]]
-deps = ["Arpack", "LinearAlgebra", "Printf", "Random", "SparseArrays", "Statistics", "StatsBase", "Test"]
-git-tree-sha1 = "cf1c990020bc4a52ff34ba2ee058b7cb677141f2"
-uuid = "6f286f6a-111f-5878-ab1e-185364afe411"
-version = "0.6.0"
-
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
 git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
@@ -170,12 +129,6 @@ git-tree-sha1 = "b6c91fc0ab970c0563cbbe69af18d741a49ce551"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
 version = "0.9.6"
 
-[[Parsers]]
-deps = ["Dates", "Mmap", "Test", "WeakRefStrings"]
-git-tree-sha1 = "fa95f29a7dc171e896e6dd74e25dddbccee2e0a5"
-uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.2.18"
-
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -183,16 +136,6 @@ uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-
-[[Profile]]
-deps = ["Printf"]
-uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
-
-[[ProgressMeter]]
-deps = ["Distributed", "Printf", "Random", "Test"]
-git-tree-sha1 = "48058bc11607676e5bbc0b974af79106c6200787"
-uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
-version = "0.9.0"
 
 [[QuadGK]]
 deps = ["DataStructures", "LinearAlgebra", "Test"]
@@ -219,12 +162,6 @@ deps = ["Test"]
 git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "0.5.2"
-
-[[Revise]]
-deps = ["Distributed", "FileWatching", "InteractiveUtils", "LibGit2", "OrderedCollections", "Pkg", "REPL", "Random", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "341be2df64de382559e2cc307e02ed4192f8a8b7"
-uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "1.0.2"
 
 [[Rmath]]
 deps = ["BinaryProvider", "Libdl", "Random", "Statistics", "Test"]
@@ -305,12 +242,6 @@ version = "0.1.14"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[TranscodingStreams]]
-deps = ["Pkg", "Random", "Test"]
-git-tree-sha1 = "a34a2d588e2d2825602bf14a24216d5c8b0921ec"
-uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.8.1"
-
 [[URIParser]]
 deps = ["Test", "Unicode"]
 git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
@@ -323,9 +254,3 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[WeakRefStrings]]
-deps = ["Missings", "Random", "Test"]
-git-tree-sha1 = "bccf012a0e8815410ad8b6846944a33903992fc3"
-uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
-version = "0.5.6"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -67,33 +67,9 @@ version = "0.15.0"
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[DecisionTree]]
-deps = ["DelimitedFiles", "Distributed", "LinearAlgebra", "Random", "ScikitLearnBase", "Statistics", "Test"]
-git-tree-sha1 = "a0a1b9f70f9c57819aed52b2ce570de77bf0a6cf"
-uuid = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
-version = "0.8.1"
-
 [[DelimitedFiles]]
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-
-[[DiffEqDiffTools]]
-deps = ["LinearAlgebra", "Test"]
-git-tree-sha1 = "4b21dd83c341412a0607334ac64bb5593a4bd583"
-uuid = "01453d9d-ee7c-5054-8395-0335cb756afa"
-version = "0.8.0"
-
-[[DiffResults]]
-deps = ["Compat", "StaticArrays"]
-git-tree-sha1 = "34a4a1e8be7bc99bc9c611b895b5baf37a80584c"
-uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
-version = "0.0.4"
-
-[[DiffRules]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "26b96a1a506b06cb272ef60568d478adab039b96"
-uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "0.0.9"
 
 [[Distances]]
 deps = ["LinearAlgebra", "Printf", "Random", "Statistics", "Test"]
@@ -111,45 +87,9 @@ git-tree-sha1 = "c24e9b6500c037673f0241a2783472b8c3d080c7"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 version = "0.16.4"
 
-[[ElasticArrays]]
-deps = ["Compat"]
-git-tree-sha1 = "ea538a92534b6466338d00b913bc1adf6dea7588"
-uuid = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
-version = "0.3.0"
-
-[[ElasticPDMats]]
-deps = ["LinearAlgebra", "MacroTools", "PDMats", "Test"]
-git-tree-sha1 = "c6ac4406d9b4a549f7316fc746f7ccd5f1bcd2cd"
-uuid = "2904ab23-551e-5aed-883f-487f97af5226"
-version = "0.2.1"
-
-[[FastGaussQuadrature]]
-deps = ["Compat", "LinearAlgebra", "SpecialFunctions"]
-git-tree-sha1 = "3861ecfe06076f9310a43469fbb676aaeba7893d"
-uuid = "442a2c76-b920-505d-bb47-c5924d526838"
-version = "0.3.2"
-
-[[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
-git-tree-sha1 = "e393bd3b9102659fb24fe88caedec41f2bc2e7de"
-uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.2"
-
 [[Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
-
-[[GLM]]
-deps = ["Distributions", "LinearAlgebra", "Printf", "Random", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "StatsModels"]
-git-tree-sha1 = "7c3f988031022a26b84c1a5106a5161c7a573960"
-uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-version = "1.1.0"
-
-[[GaussianProcesses]]
-deps = ["Distances", "Distributions", "ElasticArrays", "ElasticPDMats", "FastGaussQuadrature", "ForwardDiff", "LinearAlgebra", "Optim", "PDMats", "Printf", "Random", "RecipesBase", "ScikitLearnBase", "SpecialFunctions", "StaticArrays", "Statistics", "StatsFuns", "Test"]
-git-tree-sha1 = "d27b78ff418d683df83ea7ae74f4eb545a8504ae"
-uuid = "891a1506-143c-57d2-908e-e1f8e92e6de9"
-version = "0.9.0"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -166,12 +106,6 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-
-[[LineSearches]]
-deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "Printf", "Test"]
-git-tree-sha1 = "54eb90e8dbe745d617c78dee1d6ae95c7f6f5779"
-uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
-version = "7.0.1"
 
 [[LinearAlgebra]]
 deps = ["Libdl"]
@@ -201,30 +135,6 @@ version = "0.4.0"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[NLSolversBase]]
-deps = ["Calculus", "DiffEqDiffTools", "DiffResults", "Distributed", "ForwardDiff", "LinearAlgebra", "Random", "SparseArrays", "Test"]
-git-tree-sha1 = "2bd568eda045f5ad2cbd311d71e09d7165ab2bf6"
-uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
-version = "7.3.0"
-
-[[NaNMath]]
-deps = ["Compat"]
-git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
-uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.2"
-
-[[NearestNeighbors]]
-deps = ["Distances", "LinearAlgebra", "Mmap", "StaticArrays", "Test"]
-git-tree-sha1 = "f47c5d97cf9a8caefa47e9fa9d99d8fda1a65154"
-uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-version = "0.4.3"
-
-[[Optim]]
-deps = ["Calculus", "DiffEqDiffTools", "ForwardDiff", "LineSearches", "LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "PositiveFactorizations", "Printf", "Random", "SparseArrays", "StatsBase", "Test"]
-git-tree-sha1 = "0f2a6c6ff9db396cc7af15bb1cf057a26662ff17"
-uuid = "429524aa-4258-5aef-a3af-852621145aeb"
-version = "0.17.2"
-
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
 git-tree-sha1 = "85619a3f3e17bb4761fe1b1fd47f0e979f964d5b"
@@ -246,12 +156,6 @@ version = "0.2.18"
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-[[PositiveFactorizations]]
-deps = ["LinearAlgebra", "Test"]
-git-tree-sha1 = "86ae7329c4b5c266acf5c7c524a972300d991e1c"
-uuid = "85a6dd25-e78a-55b7-8502-1745935b8125"
-version = "0.2.1"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -275,12 +179,6 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[RecipesBase]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "0b3cb370ee4dc00f47f1193101600949f3dcf884"
-uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "0.6.0"
-
 [[Reexport]]
 deps = ["Pkg"]
 git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
@@ -301,12 +199,6 @@ version = "0.5.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-
-[[ScikitLearnBase]]
-deps = ["Compat", "LinearAlgebra", "Random", "Statistics", "Test"]
-git-tree-sha1 = "0e27caac9a456b531193117c538d739d2d6e91c2"
-uuid = "6e75b9c4-186b-50bd-896f-2d2496a4843e"
-version = "0.4.1"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -334,12 +226,6 @@ git-tree-sha1 = "0b45dc2e45ed77f445617b99ff2adf0f5b0f23ea"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
 version = "0.7.2"
 
-[[StaticArrays]]
-deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
-git-tree-sha1 = "1eb114d6e23a817cd3e99abc3226190876d7c898"
-uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.10.2"
-
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -355,12 +241,6 @@ deps = ["Rmath", "SpecialFunctions", "Test"]
 git-tree-sha1 = "b3a4e86aa13c732b8a8c0ba0c3d3264f55e6bb3e"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 version = "0.8.0"
-
-[[StatsModels]]
-deps = ["Compat", "DataFrames", "StatsBase", "Test"]
-git-tree-sha1 = "b5a735dcd2be05f0af86709750d4d5f62ca4a25d"
-uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.5.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,8 @@ version = "0.1.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
-DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-GaussianProcesses = "891a1506-143c-57d2-908e-e1f8e92e6de9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -5,16 +5,16 @@ version = "0.1.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJRegistry = "a41df0fa-2d8a-11e9-1bfb-8110be68cd3e"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TOML = "191fdcea-f9f2-43e0-b922-d33f71e2abc3"
 
 [extras]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
-Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 GaussianProcesses = "891a1506-143c-57d2-908e-e1f8e92e6de9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -22,4 +22,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Clustering", "DecisionTree", "Distances", "GaussianProcesses", "GLM", "LinearAlgebra", "Random", "Test"]
+test = ["Clustering", "DecisionTree", "GaussianProcesses", "GLM", "LinearAlgebra", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,9 @@ DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 GaussianProcesses = "891a1506-143c-57d2-908e-e1f8e92e6de9"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Clustering", "DecisionTree", "Distances", "GaussianProcesses", "GLM", "Test"]
+test = ["Clustering", "DecisionTree", "Distances", "GaussianProcesses", "GLM", "LinearAlgebra", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,11 @@ version = "0.1.0"
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJRegistry = "a41df0fa-2d8a-11e9-1bfb-8110be68cd3e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TOML = "191fdcea-f9f2-43e0-b922-d33f71e2abc3"
 
@@ -22,4 +24,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Clustering", "DecisionTree", "GaussianProcesses", "GLM", "LinearAlgebra", "Random", "Test"]
+test = ["Clustering", "DecisionTree", "GaussianProcesses", "GLM", "Test"]

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -120,24 +120,12 @@ MLJBase.package_uuid(::GLM_REGS)  = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 MLJBase.package_url(::GLM_REGS)   = "https://github.com/JuliaStats/GLM.jl"
 MLJBase.is_pure_julia(::GLM_REGS) = :yes
 
-# specific to regression type
-MLJBase.load_path(::Type{<:OLS})       = "MLJModels.GLM_.OLS"
+MLJBase.load_path(::Type{<:OLS})       = "MLJModels.GLM_.OLSRegressor"
 MLJBase.input_kinds(::Type{<:OLS})     = [:continuous, ]
 MLJBase.output_kind(::Type{<:OLS})     = :continuous
 MLJBase.output_quantity(::Type{<:OLS}) = :univariate
-=======
-# metadata:
-MLJBase.load_path(::Type{<:OLSRegressor}) = "MLJModels.GLM_.OLSRegressor"
-MLJBase.package_name(::Type{<:OLSRegressor}) = "GLM"
-MLJBase.package_uuid(::Type{<:OLSRegressor}) = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-MLJBase.package_url(::Type{<:OLSRegressor}) = "https://github.com/JuliaStats/GLM.jl"
-MLJBase.is_pure_julia(::Type{<:OLSRegressor}) = :yes
-MLJBase.input_kinds(::Type{<:OLSRegressor}) = [:continuous, ]
-MLJBase.output_kind(::Type{<:OLSRegressor}) = :continuous
-MLJBase.output_quantity(::Type{<:OLSRegressor}) = :univariate
->>>>>>> master
 
-MLJBase.load_path(::Type{<:GLMCount})       = "MLJModels.GLM_.GLMCount"
+MLJBase.load_path(::Type{<:GLMCount})       = "MLJModels.GLM_.GLMCountRegressor"
 MLJBase.input_kinds(::Type{<:GLMCount})     = [:continuous, ]
 MLJBase.output_kind(::Type{<:GLMCount})     = :ordered_factor_infinite
 MLJBase.output_quantity(::Type{<:GLMCount}) = :univariate

--- a/test/GLM.jl
+++ b/test/GLM.jl
@@ -18,7 +18,7 @@ atom_ols = OLSRegressor()
 fitresult, cache, report = MLJBase.fit(atom_ols, 1, MLJBase.selectrows(X, train), y[train])
 p = predict(atom_ols, fitresult, MLJBase.selectrows(X, test))
 
-p = predict_mean(ols, MLJ.selectrows(X, test))
+p = predict_mean(ols, MLJBase.selectrows(X, test))
 
 # hand made regression to compare
 
@@ -32,7 +32,7 @@ p2 = Xa1[test, :] * coefs
 
 info(atom_ols)
 
-p_distr = predict(ols, MLJ.selectrows(X, test))
+p_distr = predict(ols, MLJBase.selectrows(X, test))
 
 ###
 

--- a/test/GLM.jl
+++ b/test/GLM.jl
@@ -1,12 +1,15 @@
 module TestGLM
 
-# using Revise
 using Test
-using MLJBase
 
+using MLJBase
 import MLJModels
-import GLM # MLJModels.GLM_ now available for loading
+import GLM
 using MLJModels.GLM_
+
+###
+### OLSREGRESSOR
+###
 
 task = load_boston()
 X, y = X_and_y(task)
@@ -15,25 +18,29 @@ train, test = partition(eachindex(y), 0.7)
 
 atom_ols = OLSRegressor()
 
-fitresult, cache, report = MLJBase.fit(atom_ols, 1, MLJBase.selectrows(X, train), y[train])
-p = predict(atom_ols, fitresult, MLJBase.selectrows(X, test))
+Xtrain = selectrows(X, train)
+ytrain = selectrows(y, train)
+Xtest  = selectrows(X, test)
 
-p = predict_mean(ols, MLJBase.selectrows(X, test))
+fitresult, _, _ = fit(atom_ols, 1, Xtrain, ytrain)
+
+p = predict_mean(atom_ols, fitresult, Xtest)
 
 # hand made regression to compare
 
 Xa = MLJBase.matrix(X) # convert(Matrix{Float64}, X)
 Xa1 = hcat(Xa, ones(size(Xa, 1)))
 coefs = Xa1[train, :] \ y[train]
-
 p2 = Xa1[test, :] * coefs
 
 @test p ≈ p2
 
 info(atom_ols)
 
-p_distr = predict(ols, MLJBase.selectrows(X, test))
+p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
+###
+### GLMCOUNT
 ###
 
 using Random: seed!
@@ -42,7 +49,7 @@ using Distributions
 seed!(0)
 
 X = randn(100, 3) .* randn(3)'
-Xtable = MLJ.table(X)
+Xtable = table(X)
 
 α = 0.1
 β = [-0.3, 0.2, -0.1]
@@ -52,12 +59,11 @@ y = [rand(Poisson(λᵢ)) for λᵢ ∈ λ]
 
 atom_glmcount = GLMCount()
 
-glmc = machine(atom_glmcount, Xtable, y)
-fit!(glmc)
+fitresult, _, _ = fit(atom_glmcount, 1, Xtable, y)
 
-p = predict_mean(glmc, Xtable)
+p = predict_mean(atom_glmcount, fitresult, Xtable)
 
-p_distr = predict(glmc, Xtable)
+p_distr = predict(atom_glmcount, fitresult, Xtable)
 
 end # module
 true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@
 # eg, `module TestDatasets` for code testing `datasets.jl`.
 
 using Test
+using Pkg
+Pkg.add(PackageSpec(url="https://github.com/alan-turing-institute/MLJ.jl", rev="master")) 
 
 @testset "DecisionTree" begin
   @test include("DecisionTree.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@
 using Test
 
 # using Pkg
-# Pkg.add(PackageSpec(url="https://github.com/alan-turing-institute/MLJ.jl", rev="master")) 
+# Pkg.add(PackageSpec(url="https://github.com/alan-turing-institute/MLJ.jl", rev="master"))
 
 @testset "DecisionTree" begin
   @test include("DecisionTree.jl")


### PR DESCRIPTION
Follow up from #2 cleaned up so that

**key**

* `predict(::OLS)` outputs a vector  of Normal
* `predict(::GLMCount)` outputs a  vector of Poisson
* `predict_mean` works as pointwise predict

**minor**

* I included changes to `*.toml` files, hopefully Travis will be ok with it (looks like it is, cool!)
* metadata fixed as per comments in #2 
* waiting for a pending discussion on binary outputs etc to implement `GLMBinary` etc (with Binomial/Probit and all that jazz)