### PR TITLE
Revert "add hack for testing XGBoost (see test/runtests.jl)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ NaiveBayes = "9bbee03b-0db5-5f46-924f-b5c9c21b8c60"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ScikitLearn = "3646fa90-6ef7-5e7e-9f22-8aca16db6324"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [targets]
-test = ["Clustering", "DecisionTree", "GLM", "GaussianProcesses", "NaiveBayes", "Pkg", "ScikitLearn", "Test"]
+test = ["Clustering", "DecisionTree", "GLM", "GaussianProcesses", "NaiveBayes", "Pkg", "ScikitLearn", "Test", "XGBoost"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,10 +33,6 @@ end
     @test include("NaiveBayes.jl")
 end
 
-# brittle hack b/s of https://github.com/dmlc/XGBoost.jl/issues/58:
-using Pkg
-Pkg.add(PackageSpec(url="https://github.com/dmlc/XGBoost.jl"))
-
 @testset "XGBoost" begin
    @test include("XGBoost.jl")
 end


### PR DESCRIPTION
This reverts commit 8603a33710a203ab1555e3d3cd7d40c4e8d0b124.

This should not be needed any more.