### PR TITLE
WIP: add sklmodel macro, add linear_model and ensemble mods

### DIFF
--- a/src/ScikitLearn.jl
+++ b/src/ScikitLearn.jl
@@ -12,6 +12,105 @@ import MLJBase
 #> for all classifiers:
 using CategoricalArrays
 
+
+function _replace_expr!(ex, rep)
+    if ex isa Expr
+        for i = 1:length(ex.args)
+            if ex.args[i] == :arg
+                ex.args[i] = rep
+            end
+            _replace_expr!(ex.args[i], rep)
+        end
+    end
+    return ex
+end
+
+"""
+    macro sklmodel(ex)
+
+Helper macro for defining interfaces ot ScikitLearn models. Struct fields require a type annotation and a default value as in the example below. Constraints for parameters (fields) are introduced as for field3 below. The constraint must refer to the parameter as `arg`. If the used parameter does not meet the constraint the default value is used.
+
+@sklmodel mutable struct SomeModel <: MLJBase.Deterministic
+    field1::Int = 1
+    field2::Any = nothing
+    field3::Float64 = 0.5::(0 < arg < 0.8)
+end
+
+MLJBase.fit and MLJBase.predict methods are also produced.
+"""
+macro sklmodel(ex)
+    # pull out defaults and constraints
+    defaults = Dict()
+    constraints = Dict()
+    stname = ex.args[2] isa Symbol ? ex.args[2] : ex.args[2].args[1]
+    fnames = Symbol[]
+    for i = 1:length(ex.args[3].args)
+        f = ex.args[3].args[i]
+        f isa LineNumberNode && continue
+        fname, ftype = f.args[1] isa Symbol ? (ff.args[1], :Any) : (f.args[1].args[1], f.args[1].args[2])
+        push!(fnames, fname)
+        if f.head == :(=)
+            default = f.args[2]
+            if default isa Expr
+                constraints[fname] = default.args[2]
+                default = default.args[1]
+            end
+            defaults[fname] = default
+            ex.args[3].args[i] = f.args[1]
+        end
+    end
+    
+    # make kw constructor
+    const_ex = Expr(:function, 
+        Expr(:call, stname, Expr(:parameters, [Expr(:kw, fname, defaults[fname]) for fname in fnames]...)),
+        Expr(:block,
+            Expr(:(=), :model, Expr(:call, :new, [fname for fname in fnames]...)),
+            :(message = MLJBase.clean!(model)),
+            :(isempty(message) || @warn message),
+            :(return model)
+        )
+    )
+    push!(ex.args[3].args, const_ex)
+    
+    # add fit method
+    fit_ex = :(function MLJBase.fit(model::$stname, verbosity::Int, X, y)
+        Xmatrix = MLJBase.matrix(X)
+        cache = $(Symbol(stname, "_"))($([Expr(:kw, fname, :(model.$fname)) for fname in fnames]...))
+        result = ScikitLearn.fit!(cache, Xmatrix, y)
+        fitresult = result
+        report = NamedTuple{}()
+        return (fitresult, nothing, report)
+    end)
+
+    clean_ex = Expr(:function,:(MLJBase.clean!(model::$stname)),
+    Expr(:block,
+        :(warning = ""),
+        [Expr(:if, Expr(:call, :!, _replace_expr!(c, :(model.$f))), 
+        Expr(:block, 
+            :(warning *= $("constraint ($c) failed for $f, using default: $(defaults[f])\n")),
+            :(model.$f = $(defaults[f]))
+            )) for (f,c) in constraints]...,
+        :(return warning)
+        )
+    )
+
+    predict_ex = Expr(:function, 
+        :(MLJBase.predict(model::$stname, fitresult, Xnew)),
+        Expr(:block,
+            :(xnew = MLJBase.matrix(Xnew)),
+            :(prediction = ScikitLearn.predict(fitresult, xnew)),
+            :(return prediction)
+        )
+    )
+    
+    quote
+        $(esc(ex))
+        $(esc(fit_ex))
+        $(esc(clean_ex))
+        $(esc(predict_ex))
+    end
+end
+
 #> import package:
 import ..ScikitLearn: @sk_import
 import ..ScikitLearn
@@ -21,6 +120,7 @@ import ..ScikitLearn
 @sk_import svm: SVR
 @sk_import svm: NuSVR
 @sk_import svm: LinearSVR
+
 
 
 """
@@ -635,74 +735,297 @@ MLJBase.input_is_multivariate(::Type{<:SVM}) = true
 # LINEAR MODEL #
 ################
 
-# to avoid name conflicts we use this instead of @sk_import:
-(ScikitLearn.Skcore).import_sklearn()
-ElasticNet_ =
-    (ScikitLearn.Skcore.pyimport)("sklearn.linear_model")[:ElasticNet]
-ElasticNetCV_ =
-    (ScikitLearn.Skcore.pyimport)("sklearn.linear_model")[:ElasticNetCV]
- 
 
-## ELASTIC NET
 
-"""
-   ElasticNet(; kwargs...)
-ElasticNet from
-[https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNet.html). Implemented hyperparameters as per
-package documentation cited above.
-
-"""
-mutable struct ElasticNet <: MLJBase.Deterministic
-    alpha::Float64
-    l1_ratio::Float64
-    fit_intercept::Bool
-    normalize::Bool
-    precompute::Bool
-    max_iter::Int
-    copy_X::Bool
-    tol::Float64
-    warm_start::Bool
-    positive::Bool
-    selection::String
+ARDRegression_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).ARDRegression
+@sklmodel mutable struct ARDRegression <: MLJBase.Deterministic
+    n_iter::Int = 300::(arg>0)
+    tol::Float64 = 0.001
+    alpha_1::Float64 = 1e-6
+    alpha_2::Float64 = 1e-6
+    lambda_1::Float64 = 1e-6
+    lambda_2::Float64 = 1e-6
+    compute_score::Bool = false
+    threshhold_lambda::Float64 = 1.0e4
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    copy_X::Bool = true
+    verbose::Bool = false
 end
 
-# constructor:
-#> all arguments are kwargs with a default value
-function ElasticNet(
-    ;alpha=1.0
-    ,l1_ratio = 0.5
-    ,fit_intercept = true
-    ,normalize=false
-    ,precompute=false
-    ,max_iter=1000
-    ,copy_X=true
-    ,tol=0.0001
-    ,warm_start=false
-    ,positive=false
-    ,selection="cyclic")
-
-    model = ElasticNet(
-        alpha
-        , l1_ratio
-        , fit_intercept
-        , normalize
-        , precompute
-        , max_iter
-        , copy_X
-        , tol
-        , warm_start
-        , positive
-        , selection
-        )
-
-    message = MLJBase.clean!(model)       #> future proof by including these
-    isempty(message) || @warn message #> two lines even if no clean! defined below
-
-    return model
+LassoCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).BayesianRidge
+@sklmodel mutable struct BayesianRidge <: MLJBase.Deterministic
+    n_iter::Int = 300::(arg>0)
+    tol::Float64 = 0.001
+    alpha_1::Float64 = 1e-6
+    alpha_2::Float64 = 1e-6
+    lambda_1::Float64 = 1e-6
+    lambda_2::Float64 = 1e-6
+    compute_score::Bool = false
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    copy_X::Bool = true
+    verbose::Bool = false
 end
 
+ElasticNet_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).ElasticNet
+@sklmodel mutable struct ElasticNet <: MLJBase.Deterministic
+    alpha::Float64 = 1.0
+    l1_ratio::Float64 = 0.5
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    precompute::Any = false
+    max_iter::Int = 1000
+    copy_X::Bool = true
+    tol::Float64 = 0.0001
+    warm_start::Bool = false
+    positive::Bool = false
+    random_state::Any = nothing
+    selection::String = "cyclic"
+end
 
-function MLJBase.clean!(model::ElasticNet)
+ElasticNetCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).ElasticNetCV
+@sklmodel mutable struct ElasticNetCV <: MLJBase.Deterministic
+    l1_ratio::Union{Float64, Any} = 0.5
+    eps::Float64 = 0.001
+    n_alphas::Int = 100
+    alphas::Any = nothing
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    precompute::Any = "auto"
+    max_iter::Int = 1000
+    tol::Float64 = 0.0001
+    cv::Any = 5
+    copy_X::Bool = true
+    verbose::Union{Bool, Int} = 0
+    n_jobs::Union{Int, Any} = nothing
+    positive::Bool = false
+    random_state::Union{Int, Nothing} = nothing
+    selection::String = "cyclic"
+end
+
+HuberRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).HuberRegressor
+@sklmodel mutable struct HuberRegressor <: MLJBase.Deterministic
+    epsilon::Float64 = 1.35::(arg>1.0)
+    max_iter::Int = 1000
+    alpha::Float64 = 0.0001
+    warm_start::Bool = false
+    fit_intercept::Bool = true
+    tol::Float64 = 1e-5
+end
+
+Lars_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Lars
+@sklmodel mutable struct Lars <: MLJBase.Deterministic
+    fit_intercept::Bool = true
+    verbose::Union{Bool,Int} = 0
+    normalize::Bool = true
+    eps::Float64 = 1e-8
+    copy_X::Bool = true
+    fit_path::Bool = true
+    positive::Bool = false
+end
+
+LarsCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).LarsCV
+@sklmodel mutable struct LarsCV <: MLJBase.Deterministic
+    fit_intercept::Bool = true
+    verbose::Union{Bool,Int} = 0
+    normalize::Bool = true
+    precompute::Any = "auto"
+    cv::Any = 5
+    max_n_alphas::Union{Nothing,Int} = nothing
+    n_jobs::Union{Nothing,Int} = nothing
+    eps::Float64 = 1e-8
+    copy_X::Bool = true
+    positive::Bool = false
+end
+
+LassoCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).LassoCV
+@sklmodel mutable struct LassoCV <: MLJBase.Deterministic
+    eps::Float64 = 0.001
+    n_alphas::Int = 100
+    alphas::Any = nothing
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    precompute::Any = "auto"
+    max_iter::Int = 1000
+    tol::Float64 = 0.0001
+    copy_X::Bool = true
+    cv::Any = 5
+    verbose::Union{Bool, Int} = 0
+    n_jobs::Union{Int, Any} = nothing
+    positive::Bool = false
+    random_state::Int = nothing
+    selection::String = "cyclic"
+end
+
+LassoLars_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).LassoLars
+@sklmodel mutable struct LassoLars <: MLJBase.Deterministic
+    alpha::Float64 = 1.0
+    fit_intercept::Bool = true
+    verbose::Union{Bool, Int} = false
+    normalize::Bool = true
+    precompute::Any = "auto"
+    max_iter::Int = 500
+    eps::Float64 = 2.220446049250313e-16::(arg>0.0)
+    copy_X::Bool = true
+    fit_path::Bool = true
+    positive::Any = false
+end
+
+LassoLarsCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).LassoLarsCV
+@sklmodel mutable struct LassoLarsCV <: MLJBase.Deterministic
+    fit_intercept::Bool = true
+    verbose::Union{Bool, Int} = false
+    max_iter::Int = 500
+    normalize::Bool = true
+    precompute::Any = "auto"
+    cv::Any = 5
+    max_n_alphas::Union{Nothing,Int} = nothing
+    njobs::Union{Nothing,Int} = nothing
+    eps::Float64 = 2.220446049250313e-16::(arg>0.0)
+    copy_X::Bool = true
+    positive::Any = false
+end
+
+LinearRegression_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).LinearRegression
+@sklmodel mutable struct LinearRegression <: MLJBase.Deterministic
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    copy_X::Bool = true
+    n_jobs::Union{Int, Any} = nothing
+end
+
+MultiTaskElasticNet_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).MultiTaskElasticNet
+@sklmodel mutable struct MultiTaskElasticNet <: MLJBase.Deterministic
+    alpha::Float64 = 1.0
+    l1_ratio::Union{Float64, Vector{Float64}} = 1.0::(0<=arg<=1)
+    fit_intercept::Bool = true
+    normalize::Bool = true
+    copy_X::Bool = true
+    max_iter::Int = 500
+    tol::Float64 = 1e-6
+    warm_start::Bool = false
+    random_state::Any = nothing
+    selection::String = "cyclic"
+end
+
+MultiTaskElasticNetCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).MultiTaskElasticNetCV
+@sklmodel mutable struct MultiTaskElasticNetCV <: MLJBase.Deterministic
+    l1_ratio::Union{Float64, Vector{Float64}} = 1.0
+    eps::Float64 = 1e-3
+    n_alphas::Union{Nothing,Int} = nothing
+    alphas::Any = nothing
+    fit_intercept::Bool = true
+    normalize::Bool = true
+    max_iter::Int = 500
+    tol::Float64 = 1e-6
+    cv::Int = 5
+    copy_X::Bool = true
+    verbose::Union{Bool, Int} = 0
+    n_jobs::Union{Int, Any} = nothing
+    random_state::Any = nothing
+    selection::String = "cyclic"
+end
+
+MultiTaskLassoCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).MultiTaskLassoCV
+@sklmodel mutable struct MultiTaskLassoCV <: MLJBase.Deterministic
+    eps::Float64 = 1e-3
+    n_alphas::Union{Nothing,Int} = nothing
+    alphas::Any = nothing
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    max_iter::Int = 300
+    tol::Float64 = 1e-5
+    copy_X::Bool = true
+    cv::Any = 5
+    verbose::Union{Bool, Int} = false
+    n_jobs::Union{Int, Any} = 1
+    random_state::Any = nothing
+    selection::String = "cyclic"
+end
+
+OrthogonalMatchingPursuit_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).OrthogonalMatchingPursuit
+@sklmodel mutable struct OrthogonalMatchingPursuit <: MLJBase.Deterministic
+    n_nonzero_coefs::Union{Nothing,Int} = nothing
+    tol::Union{Nothing,Float64} = nothing
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    precompute::Any = "auto"
+end
+
+OrthogonalMatchingPursuitCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).OrthogonalMatchingPursuitCV
+@sklmodel mutable struct OrthogonalMatchingPursuitCV <: MLJBase.Deterministic
+    copy::Bool = true
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    max_iter::Union{Nothing,Int} = nothing
+    cv::Any = 5
+    n_jobs::Int = 1
+    verbose::Union{Bool, Int} = false
+end
+
+Ridge_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Ridge
+@sklmodel mutable struct Ridge <: MLJBase.Deterministic
+    alpha::Union{Float64,Vector{Float64}} = 1.0
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    copy_X::Bool = true
+    max_iter::Int = 1000
+    tol::Float64 = 1e-4
+    solver::Any = "auto"
+    random_state::Any = nothing
+end
+
+RidgeClassifier_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).RidgeClassifier
+@sklmodel mutable struct RidgeClassifier <: MLJBase.Deterministic
+    alpha::Float64 = 1.0
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    copy_X::Bool = true
+    max_iter::Int = 300
+    tol::Float64 = 1e-6
+    class_weight::Union{Any, Any} = nothing
+    solver::String = "auto"::(arg in ("auto","svg","cholesky","lsqr","sparse_cg","sag","saga"))
+    random_state::Any = nothing
+end
+
+RidgeCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).RidgeCV
+@sklmodel mutable struct RidgeCV <: MLJBase.Deterministic
+    alphas::Any = nothing
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    scoring::Any = Nothing
+    cv::Any = 5
+    gcv_mode::Any = "auto"
+    store_cv_values::Bool = false
+end
+
+RidgeClassifierCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).RidgeClassifierCV
+@sklmodel mutable struct RidgeClassifierCV <: MLJBase.Deterministic
+    alphas::Any = nothing
+    fit_intercept::Bool = true
+    normalize::Bool = false
+    scoring::Union{Nothing,String} = nothing
+    cv::Any = nothing
+    class_weight::Any = nothing
+    store_cv_values::Bool = false
+end
+
+TheilSenRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).TheilSenRegressor
+@sklmodel mutable struct TheilSenRegressor <: MLJBase.Deterministic
+    fit_intercept::Bool = true
+    copy_X::Bool = true
+    max_subpopulation::Int = 1000
+    n_subsamples::Union{Nothing,Int} = nothing
+    max_iter::Int = 300
+    tol::Float64 = 1e-3
+    random_state::Any = nothing
+    n_jobs::Int= 1
+    verbose::Bool = false
+end
+
+## hand crafted methods
+function MLJBase.clean!(model::T) where T <: Union{ElasticNet,ElasticNetCV}
     warning = ""
 	if(model.alpha<0.0)
 		warning *="alpha must be stricly positive, set to 1"
@@ -720,159 +1043,162 @@ function MLJBase.clean!(model::ElasticNet)
 end
 
 
-function MLJBase.fit(model::ElasticNet
-             , verbosity::Int   #> must be here (and typed) even if not used (as here)
-             , X
-             , y)
-
-    Xmatrix = MLJBase.matrix(X)
-
-    cache = ElasticNet_(alpha=model.alpha,
-            l1_ratio=model.l1_ratio,
-            fit_intercept=model.fit_intercept,
-            normalize=model.normalize,
-            precompute=model.precompute,
-            max_iter=model.max_iter,
-	    copy_X=model.copy_X,
-            tol=model.tol,
-            warm_start=model.warm_start,
-            positive=model.positive )
-
-    result = ScikitLearn.fit!(cache,Xmatrix,y)
-    fitresult = result
-	report = NamedTuple{(:n_iter,:dual_gap)}((fitresult.n_iter_, fitresult.dual_gap_))
-    return fitresult, nothing, report
-
-end
-
 function MLJBase.fitted_params(model::ElasticNet, fitresult)
 	 return NamedTuple{(:intercept,:coef)}((fitresult.intercept_,fitresult.coef_))
-end
-
-
-function MLJBase.predict(model::ElasticNet
-                         , fitresult
-                         , Xnew)
-    xnew = MLJBase.matrix(Xnew)
-    prediction = ScikitLearn.predict(fitresult,xnew)
-    return prediction
-end
-
-
-## ELASTIC NET CV 
-
-"""
-   ElasticNetCV(; kwargs...)
-ElasticNetCV from
-[https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNetCV.html](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ElasticNetCV.html). Implemented hyperparameters as per
-package documentation cited above.
-
-"""
-mutable struct ElasticNetCV <: MLJBase.Deterministic
-        l1_ratio
-	eps::Float64
-	n_alphas::Int
-	alphas
-	fit_intercept::Bool
-	normalize::Bool
-	precompute
-	max_iter::Int
-	tol::Float64
-	cv
-	copy_X::Bool
-	positive::Bool
-	selection::String
-end
-
-MLJBase.@set_defaults(ElasticNetCV(
-    #l1_ratio =
-    0.5,
-    # eps=
-    0.001,
-    # n_alphas=
-    100,
-    # alphas=
-    nothing,
-    # fit_intercept =
-    true,
-    # normalize=
-    false,
-    # precompute=
-    false,
-    # max_iter=
-    1000,
-    # tol=
-    0.0001,
-    # cv=
-    nothing,
-    # copy_X=
-    true,
-    # positive=
-    false,
-    # selection=
-    "cyclic"))
-
-
-function MLJBase.clean!(model::ElasticNetCV)
-    warning = ""
-	if(model.alphas!=nothing)
-		if(model.alphas<0.0)
-			warning *="alpha must be stricly positive, set to 1"
-			model.alphas=1
-		end
-	end
-	if(model.l1_ratio!=nothing)
-		for (iter,val) in enumerate(model.l1_ratio)
-			if(!(0<val<=1))
-				warning *="l1 must be in (0,1], set to 1"
-				model.l1_ratio[iter]=1
-			end
-		end
-	end
-	return warning
-end
-
-function MLJBase.fit(model::ElasticNetCV
-             , verbosity::Int   #> must be here (and typed) even if not used (as here)
-             , X
-             , y)
-
-    Xmatrix = MLJBase.matrix(X)
-
-    cache = ElasticNetCV_(l1_ratio=model.l1_ratio
-			  , eps=model.eps
-			  , n_alphas = model.n_alphas
-			  , alphas = model.alphas
-			  , fit_intercept = model.fit_intercept
-			  , normalize = model.normalize
-			  , precompute = model.precompute
-			  , max_iter = model.max_iter
-			  , tol = model.tol
-			  , cv = model.cv
-			  , copy_X = model.copy_X
-			  , positive = model.positive
-			  , selection = model.selection
-			  )
-
-    result = ScikitLearn.fit!(cache,Xmatrix,y)
-    fitresult = result
-    report = NamedTuple{(:l1_ratio,:alpha,:n_iter,:dual_gap)}((fitresult.l1_ratio_,fitresult.alpha_,fitresult.n_iter_,fitresult.dual_gap_))
-
-    return fitresult, nothing, report
-
 end
 
 function MLJBase.fitted_params(model::ElasticNetCV, fitresult)
 	 return NamedTuple{(:intercept,:coef)}((fitresult.intercept_,fitresult.coef_))
 end
 
-function MLJBase.predict(model::ElasticNetCV
-                         , fitresult
-                         , Xnew)
-    xnew = MLJBase.matrix(Xnew)
-    prediction = ScikitLearn.predict(fitresult,xnew)
-    return prediction
+
+
+
+GaussianProcessRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.gaussian_process")).GaussianProcessRegressor
+@sklmodel mutable struct GaussianProcessRegressor <: MLJBase.Deterministic
+    kernel::Any = nothing
+    alpha::Union{Float64, Any} = 1.0e-10
+    optimizer::Union{String, Any} = "fmin_l_bfgs_b"
+    n_restarts_optimizer::Int = 0
+    normalize_y::Bool = false
+    copy_X_train::Bool = true
+    random_state::Any = nothing
 end
+
+#### Ensemble
+
+AdaBoostRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).AdaBoostRegressor
+@sklmodel mutable struct AdaBoostRegressor <: MLJBase.Deterministic
+    base_estimator::Any = nothing
+    n_estimators::Int = 50
+    learning_rate::Float64 = 1.0
+    loss::Any = "linear"::(arg in ("linear","square","exponential"))
+    random_state::Union{Nothing,Int} = nothing
+end
+
+BaggingRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).BaggingRegressor
+@sklmodel mutable struct BaggingRegressor <: MLJBase.Deterministic
+    base_estimator::Any = nothing
+    n_estimators::Int = 10
+    max_samples::Union{Int, Float64} = 1.0
+    max_features::Union{Int, Float64} = 1.0
+    bootstrap::Bool = true
+    bootstrap_features::Bool = false
+    oob_score::Bool = false
+    warm_start::Bool = false
+    n_jobs::Union{Int, Any} = nothing
+    random_state::Any = nothing
+    verbose::Int = 0
+end
+
+GradientBoostingRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).GradientBoostingRegressor
+mutable struct GradientBoostingRegressor <: MLJBase.Deterministic
+    loss::String = "ls"::(arg in ("ls","lad","huber","quantile"))
+    learning_rate::Float64 = 0.1
+    n_estimators::Int = 100
+    subsample::Float64 = 1.0
+    criterion::String = "friedman_mse"
+    min_samples_split::Union{Int, Float64} = 2
+    min_samples_leaf::Union{Int, Float64} = 1
+    min_weight_fraction_leaf::Float64 = 0.0
+    max_depth::Int = 3
+    min_impurity_decrease::Float64 = 0.0
+    min_impurity_split::Float64 = 1e-7
+    init::Union{Any, Any} = nothing
+    random_state::Any = nothing
+    max_features::Any = Nothing
+    alpha::Float64 = 0.9
+    verbose::Int =0
+    max_leaf_nodes::Union{Int, Any} = nothing
+    warm_start::Bool = false
+    presort::Union{Bool, Any} = "auto"
+    validation_fraction::Float64 = 0.1
+    n_iter_no_change::Union{Nothing,Int} = nothing
+    tol::Float64 = 1e-4
+end
+
+HistGradientBoostingRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).HistGradientBoostingRegressor
+@sklmodel mutable struct HistGradientBoostingRegressor <: MLJBase.Deterministic
+    loss::Any = "least_squares"
+    learning_rate::Float64 = 0.1
+    max_iter::Int = 100
+    max_leaf_nodes::Int = 31
+    max_depth::Union{Int, Nothing} = nothing
+    min_samples_leaf::Int = 20
+    l2_regularization::Float64 = 0.0
+    max_bins::Int = 256
+    scoring::Any = nothing
+    validation_fraction::Union{Int, Float64, Nothing} = 0.1
+    n_iter_no_change::Union{Int, Nothing} = nothing
+    tol::Union{Float64, Any} = 1e-7
+    random_state::Any = nothing
+end
+
+RandomForestRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).RandomForestRegressor
+@sklmodel mutable struct RandomForestRegressor <: MLJBase.Deterministic
+    n_estimators::Int = 10::(arg>0)
+    criterion::String = "mse"
+    max_depth::Union{Int, Nothing} = nothing
+    min_samples_split::Union{Int, Float64} = 2
+    min_samples_leaf::Union{Int, Float64} = 1
+    min_weight_fraction_leaf::Float64 = 0.0
+    max_features::Union{Int, Float64, String, Nothing} = "auto"
+    max_leaf_nodes::Union{Int, Nothing} = nothing
+    min_impurity_decrease::Float64 = 0.0
+    min_impurity_split::Float64 = 1e-7
+    bootstrap::Bool = true
+    oob_score::Bool = false
+    n_jobs::Union{Int, Nothing} = nothing
+    random_state::Any = nothing
+    verbose::Int = 0
+    warm_start::Bool = false
+end
+
+VotingRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).VotingRegressor
+@sklmodel mutable struct VotingRegressor <: MLJBase.Deterministic
+    estimators::Any = nothing
+    weights::Any = nothing
+    n_jobs::Union{Int, Any} = nothing
+end
+
+
+
+
+
+GraphicalLassoCV_ = ((ScikitLearn.Skcore).pyimport("sklearn.covariance")).GraphicalLassoCV
+@sklmodel mutable struct GraphicalLassoCV <: MLJBase.Deterministic
+    alphas::Union{Nothing,Int,Vector{Int}} = nothing
+    n_refinements::Int = 5::(arg>0)
+    cv::Any = nothing
+    tol::Union{Nothing,Float64} = nothing
+    enet_tol::Union{Nothing,Float64} = nothing
+    max_iter::Union{Nothing,Int} = nothing
+    mode::String = "cd"::(arg in ("cd","lars"))
+    n_jobs::Union{Nothing,Int} = nothing
+    verbose::Bool = false
+    assume_centered::Bool = false
+end
+
+
+
+# needs sense check on defaults
+
+
+# RANSACRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).RANSACRegressor
+# mutable struct RANSACRegressor <: MLJBase.Deterministic
+#     base_estimator::Any = nothing
+#     min_samples::Union{Int,Float64} = 5::(arg isa Int ? arg <= 1 : !(0.0 <= arg <= 1.0))
+#     residual_threshold::Union{Nothing,Float64} = nothing
+#     is_data_valid::Any = nothing
+#     is_model_valid::Any = nothing
+#     max_trials::Union{Nothing, Int} = nothing
+#     max_skips::Union{Nothing, Int} = nothing
+#     stop_n_inliers::Union{Nothing, Int} = nothing
+#     stop_score::Union{Nothing, Float64} = nothing
+#     stop_probability::Float64 = 0.99::(0.0<=arg<=1.0)
+#     loss::String = "absolute_loss"::(arg in ("absolute_loss","squared_loss"))
+#     random_state::Any = nothing
+# end
 
 
 ## METATDATA

--- a/test/ScikitLearn.jl
+++ b/test/ScikitLearn.jl
@@ -144,7 +144,33 @@ fitted = fitted_params(rgs, fitresult)
 
 
 
+import ScikitLearn: @sk_import
+@sk_import datasets: (make_friedman2, make_regression)
+@sk_import gaussian_process.kernels: (DotProduct, WhiteKernel)
 
+
+X,y = make_friedman2()
+gpr = ScikitLearn_.GaussianProcessRegressor(kernel = DotProduct() + WhiteKernel(), random_state = 1)
+res, cache, rep = MLJBase.fit(gpr, 1, X,y);
+res.score(X,y)
+predict(gpr, res, X[2:end, :])
+
+
+X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=false)
+reg = ScikitLearn_.AdaBoostRegressor(random_state=0, n_estimators=100)
+res, cache, rep = MLJBase.fit(reg, 1, X,y);
+@test norm(predict(regr, res, [0 0 0 0])[1] - 4.7972) < 1e-4
+@test norm(res.score(X, y) - 0.9771) < 1e-4
+
+reg = ScikitLearn_.LassoLars(alpha = 0.01)
+res, cache, rep = MLJBase.fit(clf, 1, [-1 1; 0 0; 1 1], [-1,0,-1])
+@test norm(res.coef_ - [0, -0.963257]) < 1e-4
+
+seed!(0)
+X,y = randn(10, 5), randn(10)
+reg = ScikitLearn_.Ridge(alpha = 1.0)
+res, cache, rep = MLJBase.fit(reg, 1, X, y)
+@test norm(res.intercept_ - -0.78011) < 1e-5
 
 
 info(SVMClassifier)

--- a/test/ScikitLearn.jl
+++ b/test/ScikitLearn.jl
@@ -145,33 +145,161 @@ fitted = fitted_params(rgs, fitresult)
 
 
 import ScikitLearn: @sk_import
-@sk_import datasets: (make_friedman2, make_regression)
+@sk_import datasets: (make_friedman2, make_regression, load_breast_cancer, load_diabetes)
 @sk_import gaussian_process.kernels: (DotProduct, WhiteKernel)
 
 
-X,y = make_friedman2()
-gpr = ScikitLearn_.GaussianProcessRegressor(kernel = DotProduct() + WhiteKernel(), random_state = 1)
-res, cache, rep = MLJBase.fit(gpr, 1, X,y);
-res.score(X,y)
-predict(gpr, res, X[2:end, :])
+@testset "ARDRegression" begin
+    reg = ScikitLearn_.ARDRegression()
+    res, cache, rep = MLJBase.fit(reg, 1, [0 0; 1 1; 2 2], [0,1,2])
+    @test MLJBase.predict(reg, res, [1 1]) == [1.0]
+end
 
+@testset "BayesianRidge" begin
+    reg = ScikitLearn_.BayesianRidge()
+    res, cache, rep = MLJBase.fit(reg, 1, [0 0; 1 1; 2 2], [0,1,2])
+@test MLJBase.predict(reg, res, [1 1]) == [1.0]
+end
 
-X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=false)
-reg = ScikitLearn_.AdaBoostRegressor(random_state=0, n_estimators=100)
-res, cache, rep = MLJBase.fit(reg, 1, X,y);
-@test norm(predict(regr, res, [0 0 0 0])[1] - 4.7972) < 1e-4
-@test norm(res.score(X, y) - 0.9771) < 1e-4
+@testset "HuberRegressor" begin
+    X, y = make_regression(n_samples=200, n_features=2, noise = 4.0, coef = true, random_state=0)
+    X[1:4,:] = rand(4,2).*10 .+ 10
+    y[1:4] = rand(4).*10 .+ 10
+    reg = ScikitLearn_.HuberRegressor()
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    res.score(X,y)
+    MLJBase.predict(reg, res, X[1:1,:])
+end
 
-reg = ScikitLearn_.LassoLars(alpha = 0.01)
-res, cache, rep = MLJBase.fit(clf, 1, [-1 1; 0 0; 1 1], [-1,0,-1])
-@test norm(res.coef_ - [0, -0.963257]) < 1e-4
+@testset "Lars" begin
+    reg = ScikitLearn_.Lars()
+    res, cache, rep = MLJBase.fit(reg, 1, [-1 1; 0 0; 1 1], [-1.1111, 0, -1.1111])
+    @test norm(res.coef_ - [0,-1.1111]) < 1e-5
+end
 
-seed!(0)
-X,y = randn(10, 5), randn(10)
-reg = ScikitLearn_.Ridge(alpha = 1.0)
-res, cache, rep = MLJBase.fit(reg, 1, X, y)
-@test norm(res.intercept_ - -0.78011) < 1e-5
+@testset "LarsCV" begin
+    X, y = make_regression(n_samples=200, noise = 4.0, random_state=0)
+    reg = ScikitLearn_.LarsCV(cv = 5)
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test abs(res.score(X, y) - 0.9996) < 1e-4
+end
 
+@testset "Lasso" begin
+    reg = ScikitLearn_.Lasso(alpha = 0.1)
+    res, cache, rep = MLJBase.fit(reg, 1, [0 0; 1 1; 2 2], [0, 1, 2])
+    @test norm(res.coef_ - [0.85, 0.]) == 0.0
+end
+
+@testset "LassoCV" begin
+    X, y = make_regression(noise = 4.0, random_state=0)
+    reg = ScikitLearn_.LassoCV(cv = 5, random_state = 0)
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test abs(res.score(X,y) - 0.9993) < 1e-4
+    @test norm(MLJBase.predict(reg, res, X[1:1, :]) - [-78.4951]) < 1e-4
+end
+
+@testset "LassoLars" begin
+    reg = ScikitLearn_.LassoLars(alpha = 0.01)
+    res, cache, rep = MLJBase.fit(clf, 1, [-1 1; 0 0; 1 1], [-1,0,-1])
+    @test norm(res.coef_ - [0, -0.963257]) < 1e-4
+end
+
+@testset "LassoLarsCV" begin
+    X, y = make_regression(noise = 4.0, random_state=0)
+    reg = ScikitLearn_.LassoLarsCV(cv = 5)
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test abs(res.score(X,y) - 0.9992) < 1e-4
+    @test norm(MLJBase.predict(reg, res, X[1:1, :]) - [-77.8723]) < 1e-4
+end
+
+@testset "LinearRegression" begin
+    reg = ScikitLearn_.LinearRegression()
+    X = [1 1; 1 2; 2 2; 2 3.]
+    y = X[:,1] .* X[:,2] .+ 3
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test abs(res.score(X,y) - 0.9992) < 1e-4
+    @test norm(MLJBase.predict(reg, res, X[1:1, :]) - [-77.8723]) < 1e-4
+end
+
+@testset "MultiTaskElasticNet" begin
+    reg = ScikitLearn_.MultiTaskElasticNet(alpha = 0.1, l1_ratio = 0.5)
+    res, cache, rep = MLJBase.fit(reg, 1, [0 0; 1 1; 2 2], [0 0; 1 1; 2 2])
+    res.coef_
+end
+
+@testset "MultiTaskElasticNetCV" begin
+    reg = ScikitLearn_.MultiTaskElasticNetCV(cv = 3, n_alphas = 100, l1_ratio = 0.5)
+    res, cache, rep = MLJBase.fit(reg, 1, [0 0; 1 1; 2 2], [0 0; 1 1; 2 2])
+end
+
+@testset "MultiTaskLassoCV" begin
+    X, y = make_regression(n_targets = 2, noise = 4, random_state=0)
+    reg = ScikitLearn_.MultiTaskLassoCV(cv = 5, random_state = 0)
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test abs(res.score(X,y) - 0.9994) < 1e-4
+    @test norm(MLJBase.predict(reg, res, X[1:1, :]) - [153.7971 94.9015]) < 1e-2
+end
+
+@testset "OrthogonalMatchingPursuit" begin
+    X, y = make_regression(noise = 4, random_state=0)
+    reg = ScikitLearn_.OrthogonalMatchingPursuit()
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test abs(res.score(X,y) - 0.9991) < 1e-4
+    @test norm(MLJBase.predict(reg, res, X[1:1, :]) - [-78.3854]) < 1e-4
+end
+
+@testset "OrthogonalMatchingPursuitCV" begin
+    X, y = make_regression(n_features = 100, n_informative = 10, noise = 4, random_state=0)
+    reg = ScikitLearn_.OrthogonalMatchingPursuitCV(cv = 5)
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test abs(res.score(X,y) - 0.9991) < 1e-4
+    @test res.n_nonzero_coefs_ == 10
+    @test norm(MLJBase.predict(reg, res, X[1:1, :]) - [-78.3854]) < 1e-4
+end
+
+@testset "Ridge" begin
+    seed!(0)
+    X,y = randn(10, 5), randn(10)
+    reg = ScikitLearn_.Ridge(alpha = 1.0)
+    res, cache, rep = MLJBase.fit(reg, 1, X, y)
+    @test norm(res.intercept_ - -0.78011) < 1e-5
+end
+
+@testset "AdaBoostRegressor" begin
+    X, y = make_regression(n_features=4, n_informative=2, random_state=0, shuffle=false)
+    reg = ScikitLearn_.AdaBoostRegressor(random_state=0, n_estimators=100)
+    res, cache, rep = MLJBase.fit(reg, 1, X,y);
+    @test norm(predict(regr, res, [0 0 0 0])[1] - 4.7972) < 1e-4
+    @test norm(res.score(X, y) - 0.9771) < 1e-4
+end
+
+@testset "GaussianProcesses.jl" begin
+    X,y = make_friedman2()
+    gpr = ScikitLearn_.GaussianProcessRegressor(kernel = DotProduct() + WhiteKernel(), random_state = 1)
+    res, cache, rep = MLJBase.fit(gpr, 1, X,y);
+    res.score(X,y)
+    MLJBase.predict(gpr, res, X[2:end, :])
+end
+
+@testset "RidgeClassifier" begin
+    X, y = load_breast_cancer(return_X_y = true)
+    reg = ScikitLearn_.RidgeClassifier()
+    res, cache, rep = MLJBase.fit(reg, 1, X,y);
+    @test norm(res.score(X, y) - 0.9595) < 1e-4
+end
+
+@testset "RidgeClassifierCV" begin
+    reg = ScikitLearn_.RidgeClassifierCV(alphas = [1e-3, 1e-2, 1e-1, 1])
+    res, cache, rep = MLJBase.fit(reg, 1, X,y);
+    @test norm(res.score(X, y) - 0.9630) < 1e-4
+end
+
+@testset "RidgeCV" begin
+    X, y = load_diabetes(return_X_y = true)
+    reg = ScikitLearn_.RidgeCV(alphas = [1e-3, 1e-2, 1e-1, 1])
+    res, cache, rep = MLJBase.fit(reg, 1, X,y);
+    @test norm(res.score(X, y) - 0.9630) < 1e-4
+end
 
 info(SVMClassifier)
 info(SVMNuClassifier)


### PR DESCRIPTION
Adds the `sklmodel` macro that adds default constructors, `clean!`, fit and predict functions for each model. Default parameters are taken from the web-scrape or scikit learn website but probably need a sense check by someone.

helper functions/traits etc will need to be added by hand

I think tests need to be added by someone a bit more familiar with these models.