### PR TITLE
Update travis script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
+  - julia_version: 1.1
+  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: latest
 
 platform:
@@ -12,7 +14,8 @@ platform:
 ## (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-  - julia_version: latest
+    - julia_version: 1.3
+    - julia_version: latest
 
 
 branches:


### PR DESCRIPTION
Update the travis script to test on stable releases (1.0-1.1-1.2) + nightlies (1.3-1.4) allowing failures on the latter.