### PR TITLE
addresses issue #45

### DIFF
--- a/src/ScikitLearn/ScikitLearn.jl
+++ b/src/ScikitLearn/ScikitLearn.jl
@@ -3,6 +3,7 @@ module ScikitLearn_
 #> for all Supervised models:
 import MLJBase
 using ScientificTypes
+using Tables
 
 #> for all classifiers:
 using CategoricalArrays
@@ -100,14 +101,21 @@ macro sk_model(ex)
     # add fit function
     fit_ex = :(function MLJBase.fit(model::$stname, verbosity::Int, X, y)
                    # body of the function
-                   Xmatrix   = MLJBase.matrix(X)
+                   Xmatrix    = MLJBase.matrix(X)
+                   yplain     = y
+                   targ_names = nothing
+                   # in multi-target case
+                   if Tables.istable(y)
+                       yplain     = MLJBase.matrix(y)
+                       targ_names = MLJBase.schema(y).names
+                   end
                    cache     = $(Symbol(stname, "_"))($([Expr(:kw, fname, :(model.$fname))
                                                             for fname in fnames]...))
-                   result    = ScikitLearn.fit!(cache, Xmatrix, y)
+                   result    = ScikitLearn.fit!(cache, Xmatrix, yplain)
                    fitresult = result
                    # TODO: we may want to use the report later on
                    report    = NamedTuple()
-                   return (fitresult, nothing, report)
+                   return ((fitresult, targ_names), nothing, report)
                end)
 
     # clean function
@@ -135,12 +143,13 @@ macro sk_model(ex)
                         )
                     )
     # predict function
-    predict_ex = Expr(:function, :(MLJBase.predict(model::$stname, fitresult, Xnew)),
+    predict_ex = Expr(:function, :(MLJBase.predict(model::$stname, (fitresult, targ_names), Xnew)),
                     # body of the predict function
         			Expr(:block,
-                         :(xnew 	     = MLJBase.matrix(Xnew)),
-                         :(prediction = ScikitLearn.predict(fitresult, xnew)),
-                         :(return prediction)
+                         :(xnew  = MLJBase.matrix(Xnew)),
+                         :(preds = ScikitLearn.predict(fitresult, xnew)),
+                         :(isa(preds, Matrix) && (preds = MLJBase.table(preds, names=targ_names))),
+                         :(return preds)
                          )
                       )
 

--- a/src/ScikitLearn/ensemble.jl
+++ b/src/ScikitLearn/ensemble.jl
@@ -37,7 +37,7 @@ AdaBoostRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).AdaBoos
     loss::String           = "linear"::(arg in ("linear","square","exponential"))
     random_state::Any      = nothing
 end
-MLJBase.fitted_params(model::AdaBoostRegressor, fitresult) = (
+MLJBase.fitted_params(model::AdaBoostRegressor, (fitresult, _)) = (
     estimators           = fitresult.estimators_,
     estimator_weights    = fitresult.estimator_weights_,
     estimator_errors     = fitresult.estimator_errors_,
@@ -59,7 +59,7 @@ BaggingRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).BaggingR
     random_state::Any   = nothing
     verbose::Int        = 0
 end
-MLJBase.fitted_params(model::BaggingRegressor, fitresult) = (
+MLJBase.fitted_params(model::BaggingRegressor, (fitresult, _)) = (
     estimators           = fitresult.estimators_,
     estimators_samples   = fitresult.estimators_samples_,
     estimators_features  = fitresult.estimators_features_,
@@ -93,7 +93,7 @@ GradientBoostingRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble"))
     n_iter_no_change::Union{Nothing,Int} = nothing
     tol::Float64          = 1e-4::(arg>0)
 end
-MLJBase.fitted_params(model::GradientBoostingRegressor, fitresult) = (
+MLJBase.fitted_params(model::GradientBoostingRegressor, (fitresult, _)) = (
     feature_importances = fitresult.feature_importances_,
 #    oob_improvement     = fitresult.oob_improvement_, # not found ?
     train_score         = fitresult.train_score_,
@@ -119,7 +119,7 @@ MLJBase.fitted_params(model::GradientBoostingRegressor, fitresult) = (
 #     tol::Float64           = 1e-7::(arg>0)
 #     random_state::Any      = nothing
 # end
-# MLJBase.fitted_params(model::HistGradientBoostingRegressor, fitresult) = (
+# MLJBase.fitted_params(model::HistGradientBoostingRegressor, (fitresult, _)) = (
 #     n_trees_per_iteration = fitresult.n_trees_per_iteration_,
 #     train_score           = fitresult.train_score_,
 #     validation_score      = fitresult.validation_score_
@@ -145,7 +145,7 @@ RandomForestRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.ensemble")).Ran
     verbose::Int        = 0
     warm_start::Bool    = false
 end
-MLJBase.fitted_params(model::RandomForestRegressor, fitresult) = (
+MLJBase.fitted_params(model::RandomForestRegressor, (fitresult, _)) = (
     estimators     = fitresult.estimators_,
     feature_importances = fitresult.feature_importances_,
     n_features     = fitresult.n_features_,
@@ -174,7 +174,7 @@ MLJBase.fitted_params(model::RandomForestRegressor, fitresult) = (
 #     verbose::Int        = 0
 #     warm_start::Bool    = false
 # end
-# MLJBase.fitted_params(model::ExtraTreeRegressor, fitresult) = (
+# MLJBase.fitted_params(model::ExtraTreeRegressor, (fitresult, _)) = (
 #     estimators     = fitresult.estimators_,
 #     feature_importances = fitresult.feature_importances_,
 #     n_features     = fitresult.n_features_,

--- a/src/ScikitLearn/gaussian-process.jl
+++ b/src/ScikitLearn/gaussian-process.jl
@@ -15,7 +15,7 @@ GaussianProcessRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.gaussian_pro
     copy_X_train::Bool = true
     random_state::Any  = nothing
 end
-MLJBase.fitted_params(model::GaussianProcessRegressor, fitresult) = (
+MLJBase.fitted_params(model::GaussianProcessRegressor, (fitresult, _)) = (
     X_train = fitresult.X_train_,
     y_train = fitresult.y_train_,
     kernel  = fitresult.kernel_,

--- a/src/ScikitLearn/linear-regressors.jl
+++ b/src/ScikitLearn/linear-regressors.jl
@@ -69,7 +69,7 @@ ARDRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).ARDRegre
     copy_X::Bool              = true
     verbose::Bool             = false
 end
-MLJBase.fitted_params(model::ARDRegressor, fitresult) = (
+MLJBase.fitted_params(model::ARDRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
@@ -93,7 +93,7 @@ BayesianRidgeRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")
     copy_X::Bool        = true
     verbose::Bool       = false
 end
-MLJBase.fitted_params(model::BayesianRidgeRegressor, fitresult) = (
+MLJBase.fitted_params(model::BayesianRidgeRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
@@ -118,7 +118,7 @@ ElasticNetRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).E
     random_state::Any   = nothing  # Int, random state, or nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::ElasticNetRegressor, fitresult) = (
+MLJBase.fitted_params(model::ElasticNetRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     )
@@ -143,7 +143,7 @@ ElasticNetCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model"))
     random_state::Any   = nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::ElasticNetCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::ElasticNetCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     l1_ratio  = fitresult.l1_ratio_,
@@ -161,7 +161,7 @@ HuberRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).HuberR
     fit_intercept::Bool = true
     tol::Float64        = 1e-5::(arg>0)
 end
-MLJBase.fitted_params(model::HuberRegressor, fitresult) = (
+MLJBase.fitted_params(model::HuberRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     scale     = fitresult.scale_,
@@ -181,7 +181,7 @@ LarsRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Lars
     fit_path::Bool  = true
 #    positive::Bool  = false  # this option is deprecated
 end
-MLJBase.fitted_params(model::LarsRegressor, fitresult) = (
+MLJBase.fitted_params(model::LarsRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alphas    = fitresult.alphas_,
@@ -204,7 +204,7 @@ LarsCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).LarsC
     copy_X::Bool      = true
 #    positive::Bool    = false # deprecated
 end
-MLJBase.fitted_params(model::LarsCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::LarsCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
@@ -229,7 +229,7 @@ LassoRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Lasso
     random_state::Any   = nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::LassoRegressor, fitresult) = (
+MLJBase.fitted_params(model::LassoRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     )
@@ -253,7 +253,7 @@ LassoCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Lass
     random_state::Int   = nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::LassoCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::LassoCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha    = fitresult.alpha_,
@@ -276,7 +276,7 @@ LassoLarsRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).La
     fit_path::Bool      = true
     positive::Any       = false
 end
-MLJBase.fitted_params(model::LassoLarsRegressor, fitresult) = (
+MLJBase.fitted_params(model::LassoLarsRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alphas    = fitresult.alphas_,
@@ -299,7 +299,7 @@ LassoLarsCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).
     copy_X::Bool        = true
     positive::Any       = false
 end
-MLJBase.fitted_params(model::LassoLarsCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::LassoLarsCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     coef_path = fitresult.coef_path_,
@@ -321,7 +321,7 @@ LassoLarsICRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).
     copy_X::Bool        = true
     positive::Any       = false
 end
-MLJBase.fitted_params(model::LassoLarsICRegressor, fitresult) = (
+MLJBase.fitted_params(model::LassoLarsICRegressor, (fitresult, _)) = (
     coef = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha = fitresult.alpha_
@@ -335,7 +335,7 @@ LinearRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Linea
     copy_X::Bool           = true
     n_jobs::Union{Nothing,Int} = nothing
 end
-MLJBase.fitted_params(model::LinearRegressor, fitresult) = (
+MLJBase.fitted_params(model::LinearRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
@@ -349,7 +349,7 @@ OrthogonalMatchingPursuitRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.li
     normalize::Bool     = true
     precompute::Union{Bool,String,AbstractMatrix} = "auto"
 end
-MLJBase.fitted_params(model::OrthogonalMatchingPursuitRegressor, fitresult) = (
+MLJBase.fitted_params(model::OrthogonalMatchingPursuitRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
@@ -365,7 +365,7 @@ OrthogonalMatchingPursuitCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.
     n_jobs::Union{Nothing,Int} = 1
     verbose::Union{Bool,Int}   = false
 end
-MLJBase.fitted_params(model::OrthogonalMatchingPursuitCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::OrthogonalMatchingPursuitCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     n_nonzero_coefs = fitresult.n_nonzero_coefs_
@@ -389,7 +389,7 @@ PassiveAggressiveRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_mod
     warm_start::Bool             = false
     average::Union{Bool,Int}     = false
 end
-MLJBase.fitted_params(model::PassiveAggressiveRegressor, fitresult) = (
+MLJBase.fitted_params(model::PassiveAggressiveRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
@@ -422,7 +422,7 @@ RidgeRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Ridge
     solver::String      = "auto"::(arg in ("auto","svd","cholesky","lsqr","sparse_cg","sag","saga"))
     random_state::Any   = nothing
 end
-MLJBase.fitted_params(model::RidgeRegressor, fitresult) = (
+MLJBase.fitted_params(model::RidgeRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
@@ -438,7 +438,7 @@ RidgeCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).Ridg
     gcv_mode::Union{Nothing,String} = nothing::(arg === nothing || arg in ("auto","svd","eigen"))
     store_cv_values::Bool  = false
 end
-MLJBase.fitted_params(model::RidgeCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::RidgeCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
@@ -468,7 +468,7 @@ SGDRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).SGDRegre
     warm_start::Bool         = false
     average::Union{Int,Bool} = false
 end
-MLJBase.fitted_params(model::SGDRegressor, fitresult) = (
+MLJBase.fitted_params(model::SGDRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     average_coef      = model.average ? fitresult.average_coef_ : nothing,
@@ -488,7 +488,7 @@ TheilSenRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model")).The
     n_jobs::Union{Nothing,Int} = nothing
     verbose::Bool       = false
 end
-MLJBase.fitted_params(model::TheilSenRegressor, fitresult) = (
+MLJBase.fitted_params(model::TheilSenRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     breakdown       = fitresult.breakdown_,
@@ -498,8 +498,8 @@ MLJBase.fitted_params(model::TheilSenRegressor, fitresult) = (
 # Metadata for Continuous -> Vector{Continuous}
 const SKL_REGS_SINGLE = Union{Type{<:ARDRegressor},Type{<:BayesianRidgeRegressor},        Type{<:ElasticNetRegressor},Type{<:ElasticNetCVRegressor},Type{<:HuberRegressor},Type{<:LarsRegressor},Type{<:LarsCVRegressor},Type{<:LassoRegressor},Type{<:LassoCVRegressor},Type{<:LassoLarsRegressor},Type{<:LassoLarsCVRegressor},Type{<:LassoLarsICRegressor},Type{<:LinearRegressor},Type{<:OrthogonalMatchingPursuitRegressor},Type{<:OrthogonalMatchingPursuitCVRegressor},Type{<:PassiveAggressiveRegressor},Type{<:RidgeRegressor},Type{<:RidgeCVRegressor},Type{<:SGDRegressor},Type{<:TheilSenRegressor}}
 
-MLJBase.input_scitype(::SKL_REGS_SINGLE)  = MLJBase.Table(MLJBase.Continuous)
-MLJBase.target_scitype(::SKL_REGS_SINGLE) = AbstractVector{MLJBase.Continuous}
+MLJBase.input_scitype(::SKL_REGS_SINGLE)  = MLJBase.Table(Continuous)
+MLJBase.target_scitype(::SKL_REGS_SINGLE) = AbstractVector{Continuous}
 
 ##############
 # MULTI TASK #
@@ -517,7 +517,7 @@ MultiTaskLassoRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_model"
     random_state::Any   = nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::MultiTaskLassoRegressor, fitresult) = (
+MLJBase.fitted_params(model::MultiTaskLassoRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
@@ -539,7 +539,7 @@ MultiTaskLassoCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_mode
     random_state::Any   = nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::MultiTaskLassoCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::MultiTaskLassoCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
@@ -561,7 +561,7 @@ MultiTaskElasticNetRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear_m
     random_state::Any   = nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::MultiTaskElasticNetRegressor, fitresult) = (
+MLJBase.fitted_params(model::MultiTaskElasticNetRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing)
     )
@@ -584,7 +584,7 @@ MultiTaskElasticNetCVRegressor_ = ((ScikitLearn.Skcore).pyimport("sklearn.linear
     random_state::Any   = nothing
     selection::String   = "cyclic"::(arg in ("cyclic","random"))
 end
-MLJBase.fitted_params(model::MultiTaskElasticNetCVRegressor, fitresult) = (
+MLJBase.fitted_params(model::MultiTaskElasticNetCVRegressor, (fitresult, _)) = (
     coef      = fitresult.coef_,
     intercept = ifelse(model.fit_intercept, fitresult.intercept_, nothing),
     alpha     = fitresult.alpha_,
@@ -595,5 +595,5 @@ MLJBase.fitted_params(model::MultiTaskElasticNetCVRegressor, fitresult) = (
 const SKL_REGS_MULTI = Union{Type{<:MultiTaskLassoRegressor}, Type{<:MultiTaskLassoCVRegressor},
        Type{<:MultiTaskElasticNetRegressor}, Type{<:MultiTaskElasticNetCVRegressor}}
 
-MLJBase.input_scitype(::SKL_REGS_MULTI)  = MLJBase.Table(MLJBase.Continuous)
-MLJBase.target_scitype(::SKL_REGS_MULTI) = MLJBase.Table(MLJBase.Continuous)
+MLJBase.input_scitype(::SKL_REGS_MULTI)  = MLJBase.Table(Continuous)
+MLJBase.target_scitype(::SKL_REGS_MULTI) = MLJBase.Table(Continuous)

--- a/test/ScikitLearn/ScikitLearn.jl
+++ b/test/ScikitLearn/ScikitLearn.jl
@@ -1,6 +1,7 @@
 module TestScikitLearn
 
 using MLJBase
+using Tables
 using Test
 using LinearAlgebra
 using Random

--- a/test/ScikitLearn/ensemble.jl
+++ b/test/ScikitLearn/ensemble.jl
@@ -10,7 +10,7 @@ y  = X1 * θ .+ 0.1 .* randn(n)
 @testset "AdaBoostReg" begin
     m = AdaBoostRegressor(random_state=0, n_estimators=100)
     f, _, _ = fit(m, 1, X, y)
-    @test 0.9 ≤ f.score(X, y) ≤ 0.999
+    @test 0.9 ≤ f[1].score(X, y) ≤ 0.999
     @test 0.2 ≤ norm(predict(m, f, X) .- y)/norm(y) ≤ 0.25
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -20,7 +20,7 @@ end
 @testset "BaggingReg" begin
     m = BaggingRegressor(random_state=0)
     f, _, _ = fit(m, 1, X, y)
-    @test 0.9 ≤ f.score(X, y) ≤ 0.999
+    @test 0.9 ≤ f[1].score(X, y) ≤ 0.999
     @test 0.15 ≤ norm(predict(m, f, X) .- y)/norm(y) ≤ 0.25
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -30,14 +30,14 @@ end
 # @testset "XTreeReg" begin
 #     m = ExtraTreeRegressor(random_state=0)
 #     f, _, _ = fit(m, 1, X, y)
-#     @test isapprox(f.score(X, y), 0.9356045, rtol=1e-5)
+#     @test isapprox(f[1].score(X, y), 0.9356045, rtol=1e-5)
 #     @test isapprox(norm(predict(m, f, X) .- y)/norm(y),  0.2352736, rtol=1e-5)
 # end
 
 @testset "GBReg" begin
     m = GradientBoostingRegressor(random_state=0)
     f, _, _ = fit(m, 1, X, y)
-    @test 0.9 ≤ f.score(X, y) ≤ 0.999
+    @test 0.9 ≤ f[1].score(X, y) ≤ 0.999
     @test 0.03 ≤ norm(predict(m, f, X) .- y)/norm(y) ≤ 0.05
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -47,7 +47,7 @@ end
 @testset "RFReg" begin
     m = RandomForestRegressor(random_state=0, oob_score=true)
     f, _, _ = fit(m, 1, X, y)
-    @test 0.9 ≤ f.score(X, y) ≤ 0.999
+    @test 0.9 ≤ f[1].score(X, y) ≤ 0.999
     @test 0.15 ≤ norm(predict(m, f, X) .- y)/norm(y) ≤ 0.25
     # testing that the fitted params is proper
     fp = fitted_params(m, f)

--- a/test/ScikitLearn/gaussian-process.jl
+++ b/test/ScikitLearn/gaussian-process.jl
@@ -8,7 +8,7 @@ y  = X1 * θ .+ 0.1 .* randn(n)
 @testset "GPRegressor" begin
     gpr = GaussianProcessRegressor(random_state = 1)
     res, _, _ = fit(gpr, 1, X, y)
-    @test res.score(X,y) ≈ 1.0
+    @test res[1].score(X,y) ≈ 1.0
     @test norm(predict(gpr, res, X) .- y) / norm(y) ≤ 1e-10 # overfitting to the max
     fp = fitted_params(gpr, res)
     @test keys(fp) == (:X_train, :y_train, :kernel, :L, :alpha, :log_marginal_likelihood_value)

--- a/test/ScikitLearn/linear-regressors.jl
+++ b/test/ScikitLearn/linear-regressors.jl
@@ -15,7 +15,7 @@ y  = X1 * θ .+ 0.1 .* randn(n)
 @testset "ARD" begin
     m = ARDRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y),  0.032693, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -25,7 +25,7 @@ end
 @testset "BayesianRidge" begin
     m = BayesianRidgeRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0326918, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -35,7 +35,7 @@ end
 @testset "ElasticNet" begin
     m = ElasticNetRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.769795, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.769795, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.464447, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -45,7 +45,7 @@ end
 @testset "ElasticNetCV" begin
     m = ElasticNetCVRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.99884, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.99884, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0328523, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -55,7 +55,7 @@ end
 @testset "Huber" begin
     m = HuberRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.99884, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.99884, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.032935, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -65,7 +65,7 @@ end
 @testset "Lars" begin
     m = LarsRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0326918, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -75,7 +75,7 @@ end
 @testset "LarsCV" begin
     m = LarsCVRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0326918, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -85,7 +85,7 @@ end
 @testset "Lasso" begin
     m = LassoRegressor(alpha = 0.1)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.9946343, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.9946343, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0709070, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -95,7 +95,7 @@ end
 @testset "LassoCV" begin
     m = LassoCVRegressor(random_state=0, cv=6)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998857, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998857, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.03272594, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -105,7 +105,7 @@ end
 @testset "LassoLars" begin
     m = LassoLarsRegressor(alpha = 0.01)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.994317, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.994317, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.072973, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -115,7 +115,7 @@ end
 @testset "LassoLarsCV" begin
     m = LassoLarsCVRegressor(cv=4)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0326918, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -125,7 +125,7 @@ end
 @testset "LassoLarsIC" begin
     m = LassoLarsICRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.9920703, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.9920703, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.08619978, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -136,7 +136,7 @@ end
     m = LinearRegressor()
     f, _, _ = fit(m, 1, X, y)
     # test if things work
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-4)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-4)
     @test isapprox(norm(predict(m, f, X) .- y) / norm(y), 0.032691, rtol=1e-4)
     fp = fitted_params(m, f)
     @test fp.coef      ≈ θ_ls[1:p]
@@ -149,7 +149,7 @@ end
 @testset "OMP" begin
     m = OrthogonalMatchingPursuitRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.4593868, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.4593868, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.711741, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -159,7 +159,7 @@ end
 @testset "OMPCV" begin
     m = OrthogonalMatchingPursuitCVRegressor(cv = 5)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0326918, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -169,7 +169,7 @@ end
 @testset "OMPCV" begin
     m = OrthogonalMatchingPursuitCVRegressor(cv = 5)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998859, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998859, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0326918, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -179,7 +179,7 @@ end
 @testset "PassAggr" begin
     m = PassiveAggressiveRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test 0.980 ≤ f.score(X, y) ≤ 0.999
+    @test 0.980 ≤ f[1].score(X, y) ≤ 0.999
     @test norm(predict(m, f, X) .- y)/norm(y) ≤ 0.1
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -189,7 +189,7 @@ end
 @testset "Ridge" begin
     m = RidgeRegressor(alpha = 1.0)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998793, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998793, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0336254, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -199,7 +199,7 @@ end
 @testset "RidgeCV" begin
     m = RidgeCVRegressor(cv=nothing, store_cv_values=true)
     f, _, _ = fit(m, 1, X, y)
-    @test isapprox(f.score(X, y), 0.998858, rtol=1e-5)
+    @test isapprox(f[1].score(X, y), 0.998858, rtol=1e-5)
     @test isapprox(norm(predict(m, f, X) .- y)/norm(y), 0.0327014, rtol=1e-5)
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -210,7 +210,7 @@ end
 @testset "SGDReg" begin
     m = SGDRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test 0.980 ≤ f.score(X, y) ≤ 0.999
+    @test 0.980 ≤ f[1].score(X, y) ≤ 0.999
     @test norm(predict(m, f, X) .- y)/norm(y) ≤ 0.1
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -220,7 +220,7 @@ end
 @testset "TheilSen" begin
     m = TheilSenRegressor()
     f, _, _ = fit(m, 1, X, y)
-    @test 0.980 ≤ f.score(X, y) ≤ 0.999
+    @test 0.980 ≤ f[1].score(X, y) ≤ 0.999
     @test norm(predict(m, f, X) .- y)/norm(y) ≤ 0.1
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
@@ -231,40 +231,49 @@ end
 # MULTI TASK #
 ##############
 
-y2 = hcat(y, y)
+y2 = (t1=y, t2=y)
 
 @testset "MTLassoCV" begin
     m = MultiTaskLassoRegressor()
     f, _, _ = fit(m, 1, X, y2)
-    @test f.coef_ isa Matrix
+    @test f[1].coef_ isa Matrix
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
     @test keys(fp) == (:coef, :intercept)
+    pred = predict(m, f, X)
+    @test pred isa Tables.MatrixTable
+    @test MLJBase.schema(pred).names == (:t1, :t2)
 end
 
 @testset "MTLassoCV" begin
     m = MultiTaskLassoCVRegressor(cv = 5, random_state = 0)
     f, _, _ = fit(m, 1, X, y2)
-    @test f.coef_ isa Matrix
+    @test f[1].coef_ isa Matrix
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
     @test keys(fp) == (:coef, :intercept, :alpha, :mse_path, :alphas)
+    @test predict(m, f, X) isa Tables.MatrixTable
 end
+
+X = MLJBase.table([0 0; 1 1; 2 2])
+y = MLJBase.table([0 0; 1 1; 2 2])
 
 @testset "MTElNet" begin
     m = MultiTaskElasticNetRegressor(alpha = 0.1, l1_ratio = 0.5)
-    f, _, _ = fit(m, 1, [0 0; 1 1; 2 2], [0 0; 1 1; 2 2])
-    @test f.coef_ isa Matrix
+    f, _, _ = fit(m, 1, X, y)
+    @test f[1].coef_ isa Matrix
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
     @test keys(fp) == (:coef, :intercept)
+    @test predict(m, f, X) isa Tables.MatrixTable
 end
 
 @testset "MTElNetCV" begin
     m = MultiTaskElasticNetCVRegressor(cv = 3, n_alphas = 100, l1_ratio = 0.5)
-    f, _, _ = fit(m, 1, [0 0; 1 1; 2 2], [0 0; 1 1; 2 2])
-    @test f.coef_ isa Matrix
+    f, _, _ = fit(m, 1, X, y)
+    @test f[1].coef_ isa Matrix
     # testing that the fitted params is proper
     fp = fitted_params(m, f)
     @test keys(fp) == (:coef, :intercept, :alpha, :mse_path, :l1_ratio)
+    @test predict(m, f, X) isa Tables.MatrixTable
 end


### PR DESCRIPTION
Small tweak in the @sk_model macro so that

1. in the multi-target case, `fit` expects a table for `y` and `predict` outputs a table
2. the name of the targets are passed

**note**: here, like in GLM, there is this slightly clunky way of passing additional informations along the "actual" fitresult which is used by the external package for the prediction; I believe it's fine for now but in some future it may be relevant to have `fit` return a 4-tuple with

```julia
return fitresult, aux_infos, cache, report
```

where `aux_infos` is possibly `nothing` or stuff like target names etc which would be passed along `fitresult` to `predict`. (we can discuss this some other time)
