### PR TITLE
Macro @mlj_model and tests

### DIFF
--- a/src/Clustering.jl
+++ b/src/Clustering.jl
@@ -9,7 +9,6 @@ export KMeans, KMedoids
 
 import MLJBase
 using ScientificTypes
-using Parameters
 
 import ..Clustering # strange sytax for lazy-loading
 
@@ -17,6 +16,8 @@ using Distances
 using LinearAlgebra: norm
 
 const C = Clustering
+
+import ..@mlj_model
 
 const KMeansDescription =
     """
@@ -46,9 +47,9 @@ $KMFields
 
 See also the [package documentation](http://juliastats.github.io/Clustering.jl/latest/kmeans.html).
 """
-@with_kw mutable struct KMeans{M<:SemiMetric} <: MLJBase.Unsupervised
-    k::Int    = 3
-    metric::M = SqEuclidean()
+@mlj_model mutable struct KMeans <: MLJBase.Unsupervised
+    k::Int = 3::(_ ≥ 2)
+    metric::SemiMetric = SqEuclidean()
 end
 
 """
@@ -60,20 +61,9 @@ $KMFields
 
 See also the [package documentation](http://juliastats.github.io/Clustering.jl/latest/kmedoids.html).
 """
-@with_kw mutable struct KMedoids{M<:SemiMetric} <: MLJBase.Unsupervised
-    k::Int    = 3
-    metric::M = SqEuclidean()
-end
-
-const CM = Union{<:KMeans, <:KMedoids}
-
-function MLJBase.clean!(model::CM)
-    warning = ""
-    if model.k < 2
-        warning *= "Need k >= 2. Setting k=2.\n"
-        model.k = 2
-    end
-    return warning
+@mlj_model mutable struct KMedoids <: MLJBase.Unsupervised
+    k::Int = 3::(_ ≥ 2)
+    metric::SemiMetric = SqEuclidean()
 end
 
 function MLJBase.fit(model::KMeans

--- a/src/MLJModels.jl
+++ b/src/MLJModels.jl
@@ -34,6 +34,7 @@ using Pkg.TOML
 const srcdir = dirname(@__FILE__) # the directory containing this file
 
 include("metadata_utils.jl")
+include("parameters_utils.jl")
 
 include("metadata.jl")
 include("model_search.jl")

--- a/src/MultivariateStats.jl
+++ b/src/MultivariateStats.jl
@@ -14,33 +14,14 @@ struct LinearFitresult{F} <: MLJBase.MLJType
     bias::F
 end
 
+import ..@mlj_model
+
 ####
 #### RIDGE
 ####
 
-mutable struct RidgeRegressor <: MLJBase.Deterministic
-    lambda::Float64
-end
-
-function MLJBase.clean!(model::RidgeRegressor)
-    warning = ""
-    if model.lambda < 0
-        warning *= "Need lambda ≥ 0. Resetting lambda=0. "
-        model.lambda = 0
-    end
-    return warning
-end
-
-# keyword constructor
-function RidgeRegressor(; lambda=0.0)
-
-    model = RidgeRegressor(lambda)
-
-    message = MLJBase.clean!(model)
-    isempty(message) || @warn message
-
-    return model
-
+@mlj_model mutable struct RidgeRegressor <: MLJBase.Deterministic
+    lambda::Float64 = 0.0::(_ ≥ 0)
 end
 
 function MLJBase.fit(model::RidgeRegressor,

--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -1,10 +1,10 @@
 module NearestNeighbors_
 
 import MLJBase
-using Parameters
 using Distances
 
 import ..NearestNeighbors
+import ..@mlj_model
 
 const NN = NearestNeighbors
 
@@ -45,13 +45,13 @@ $KNNRegressorDescription
 
 $KNNFields
 """
-@with_kw mutable struct KNNRegressor <: MLJBase.Deterministic
-    K::Int            = 5           # > 0
-    algorithm::Symbol = :kdtree     # (:kdtree, :brutetree, :balltree)
-    metric::Metric    = Euclidean() #
-    leafsize::Int     = 10          # > 0
+@mlj_model mutable struct KNNRegressor <: MLJBase.Deterministic
+    K::Int            = 5::(_ > 0)
+    algorithm::Symbol = :kdtree::(_ in (:kdtree, :brutetree, :balltree))
+    metric::Metric    = Euclidean()
+    leafsize::Int     = 10::(_ ≥ 0)
     reorder::Bool     = true
-    weights::Symbol   = :uniform    # (:uniform, :distance)
+    weights::Symbol   = :uniform::(_ in (:uniform, :distance))
 end
 
 """
@@ -61,13 +61,13 @@ $KNNClassifierDescription
 
 $KNNFields
 """
-@with_kw mutable struct KNNClassifier <: MLJBase.Probabilistic
-    K::Int            = 5           # > 0
-    algorithm::Symbol = :kdtree     # (:kdtree, :brutetree, :balltree)
-    metric::Metric    = Euclidean() #
-    leafsize::Int     = 10          # > 0
+@mlj_model mutable struct KNNClassifier <: MLJBase.Probabilistic
+    K::Int            = 5::(_ > 0)
+    algorithm::Symbol = :kdtree::(_ in (:kdtree, :brutetree, :balltree))
+    metric::Metric    = Euclidean()
+    leafsize::Int     = 10::(_ ≥ 0)
     reorder::Bool     = true
-    weights::Symbol   = :uniform    # (:uniform, :distance)
+    weights::Symbol   = :uniform::(_ in (:uniform, :distance))
 end
 
 const KNN = Union{KNNRegressor, KNNClassifier}

--- a/src/ScikitLearn/ScikitLearn.jl
+++ b/src/ScikitLearn/ScikitLearn.jl
@@ -70,7 +70,7 @@ macro sk_model(ex)
         f isa LineNumberNode && continue
 
         fname, ftype = f.args[1] isa Symbol ?
-                            (ff.args[1], :Any) :
+                            (f.args[1], :Any) :
                             (f.args[1].args[1], f.args[1].args[2])
         push!(fnames, fname)
 
@@ -150,8 +150,7 @@ macro sk_model(ex)
                          :(preds = ScikitLearn.predict(fitresult, xnew)),
                          :(isa(preds, Matrix) && (preds = MLJBase.table(preds, names=targ_names))),
                          :(return preds)
-                         )
-                      )
+                         ) )
 
     # model metadata note that it does not assign scitypes etc, these have
     # to be added manually model by model.

--- a/src/parameters_utils.jl
+++ b/src/parameters_utils.jl
@@ -1,0 +1,149 @@
+# This defines a macro `mlj_model` which is a simpler version than the
+# @sk_model macro defined to help import sklearn models.
+# The difference is that the `mlj_model` macro only defines the constructor and the `clean!`
+# and does not automatically define the `fit` and `predict` methods
+#
+# NOTE: it does NOT handle parametric types yet.
+
+import Base: @__doc__
+
+"""
+_unpack!(ex, rep)
+
+Internal function to allow to read a constraint given after a default value for a parameter
+and transform it in an executable condition (which is returned to be executed later).
+For instance if we have
+
+    alpha::Int = 0.5::(arg > 0.0)
+
+Then it would transform the `(arg > 0.0)` in `(alpha > 0.0)` which is executable.
+"""
+function _unpack!(ex, rep)
+    if ex isa Expr
+        for i in eachindex(ex.args)
+            if ex.args[i] == :_
+                ex.args[i] = rep
+            end
+            _unpack!(ex.args[i], rep)
+        end
+    end
+    return ex
+end
+
+
+"""
+mlj_model
+
+Macro to help define MLJ models with constraints on the default parameters, this can be seen as
+a tweaked version of the `@with_kw` macro from `Parameters`.
+"""
+macro mlj_model(ex)
+    # pull out defaults and constraints
+    defaults    = Dict{Symbol,Any}()
+    constraints = Dict{Symbol,Any}()
+    # name of the model
+    Model = ex.args[2] isa Symbol ? ex.args[2] : ex.args[2].args[1]
+
+    # inspect all fields, retrieve the names and the constraints
+    fnames = Symbol[]
+    for i in 1:length(ex.args[3].args)
+        # retrieve meaningful lines
+        f = ex.args[3].args[i]
+        f isa LineNumberNode && continue
+
+        # line without information (e.g. just a name "param")
+        if f isa Symbol
+            push!(fnames, f)
+            defaults[f] = missing
+        else
+            # A meaningful line will look like
+            #   f.args[1] = f.args[2]
+            #
+            # where f.args[1] will either be just `name`  or `name::Type`
+            # and   f.args[2] will either be just `value` or `value::constraint`
+
+            # -- decompose `f.args[1]` appropriately to retrieve the field name
+
+            if f.args[1] isa Symbol
+                # :a
+                fname = f.args[1]
+                ftype = length(f.args)>1 ? f.args[2] : :Any
+            else
+                # :(a::Int)
+                fname, ftype = f.args[1].args[1:2]
+            end
+            push!(fnames, fname)
+
+            # -- decompose `f.args[2]` appropriately to retrieve the value and constraint
+
+            if f.head == :(=) # assignment for default
+                default = f.args[2]
+                # if a constraint is given (value::constraint)
+                if default isa Expr
+                    if length(default.args) > 1
+                        constraints[fname] = default.args[2] # constraint
+                        default = default.args[1]
+                    end
+                end
+                defaults[fname]    = default    # this will be a value not an expr
+                ex.args[3].args[i] = f.args[1]  # name or name::Type (for the constructor)
+            else
+                eff_ftype = eval(ftype)
+                if eff_ftype <: Number
+                    defaults[fname] = zero(eff_ftype)
+                elseif eff_ftype <: AbstractString
+                    defaults[fname] = ""
+                else
+                    @error "A default value for parameter '$fname' of type '$ftype' must be " *
+                           "provided."
+                end
+            end
+        end
+    end
+
+    # Build the kw constructor
+    const_ex = Expr(:function, Expr(:call, Model, Expr(:parameters,
+     	                  [Expr(:kw, fname, defaults[fname]) for fname in fnames]...)),
+                    # body of the function
+                    Expr(:block,
+                         Expr(:(=), :model, Expr(:call, :new, [fname for fname in fnames]...)),
+                         :(message = MLJBase.clean!(model)),
+            			 :(isempty(message) || @warn message),
+            			 :(return model)
+        				 )
+    			 	)
+    push!(ex.args[3].args, const_ex)
+
+    clean_ex = Expr(:function, :(MLJBase.clean!(model::$Model)),
+                # body of the function
+                Expr(:block,
+                     :(warning = ""),
+                     # condition and action for each constraint
+                     # each parameter is given as field::Type = default::constraint
+                     # here we recuperate the constraint and express it as an if statement
+                     # for instance if we had
+                     #     alpha::Real = 0.0::(arg > 0.0)
+                     # this would become
+                     #     if !(alpha > 0.0)
+                     [Expr(:if, Expr(:call, :!, _unpack!(constr, :(model.$param))),
+                           # action of the constraint is violated:
+                           # add a message and use default for the parameter
+                           Expr(:block,
+                                :(warning *= $("Constraint `$constr` failed; using default: $param=$(defaults[param]).")),
+                                :(model.$param = $(defaults[param]))
+                                )
+                           ) for (param, constr) in constraints]...,
+                     # return full message
+                     :(return warning)
+                    )
+                )
+
+    esc(
+        quote
+            Base.@__doc__ $ex
+            export $Model
+            $ex
+            $clean_ex
+        end
+    )
+end

--- a/test/NearestNeighbors.jl
+++ b/test/NearestNeighbors.jl
@@ -39,7 +39,7 @@ ytest3 = fill("C", ntest)
 
 ytest = vcat(ytest1, ytest2, ytest3)
 
-knn = KNNClassifier(weights=:weights)
+knn = KNNClassifier(weights=:distance)
 
 f,_,_ = fit(knn, 1, x, y)
 

--- a/test/parameters_utils.jl
+++ b/test/parameters_utils.jl
@@ -1,0 +1,92 @@
+using MLJBase, Test, Distances
+using MLJModels: @mlj_model
+
+@testset "@mlj_model" begin
+    # No type, no default
+    @mlj_model mutable struct A1
+        a
+    end
+    a = A1()
+    @test ismissing(a.a)
+    a.a = 5
+    @test a.a == 5
+
+    # No type, with default
+    @mlj_model mutable struct A1b
+        a = 5
+    end
+    a = A1b()
+    @test a.a == 5
+    a.a = "hello"
+    @test a.a == "hello"
+
+    # If a type is given but no default value is given, then the macro tries to fill
+    # a default value; either 0 if it's a Number type, or an empty string and otherwise fails.
+    @mlj_model mutable struct A1c
+        a::Int
+    end
+    a = A1c()
+    @test a.a == 0
+    a = A1c(a=7)
+    @test a.a == 7
+    @test_throws InexactError A1c(a=5.3)
+    @test_throws MethodError A1c(a="hello")
+
+    # Type is given and default is given
+    @mlj_model mutable struct A1d
+        a::Int = 5
+    end
+    a = A1d()
+    @test a.a == 5
+    a = A1d(a=7)
+    @test a.a == 7
+
+    # No type is given but a default and constraint
+    @mlj_model mutable struct A1e
+        a = 5::(_ > 0)
+    end
+    a = A1e()
+    @test a.a == 5
+    a = A1e(a=7)
+    @test a.a == 7
+    @test @test_logs (:warn, "Constraint `model.a > 0` failed; using default: a=5.") A1e(a=-1).a==5
+    a = A1e(a=7.5)
+    @test a.a == 7.5
+
+    # Type is given with default and constraint
+    @mlj_model mutable struct A1f
+        a::Int = 5::(_ > 0)
+    end
+    a = A1f()
+    @test a.a == 5
+    a = A1f(a=7)
+    @test a.a == 7
+    @test_throws InexactError A1f(a=7.5)
+    @test @test_logs (:warn, "Constraint `model.a > 0` failed; using default: a=5.") A1f(a=-1).a==5
+end
+
+
+@testset "@mlj_model - advanced" begin
+    abstract type FooBar end
+    @mlj_model mutable struct B1a <: FooBar
+        a::Symbol = :auto::(_ in (:auto, :semi))
+    end
+    b = B1a()
+    @test b.a == :auto
+    b = B1a(a=:semi)
+    @test b.a == :semi
+    @test @test_logs (:warn, "Constraint `model.a in (:auto, :semi)` failed; using default: a=:auto.") B1a(a=:autos).a == :auto
+    @test_throws MethodError B1a(b="blah")
+
+    # == dependence on other types
+    @mlj_model mutable struct B1b
+        a::SemiMetric = Euclidean()::(_ isa Metric)
+    end
+    @test B1b().a isa Euclidean
+    @test @test_logs (:warn, "Constraint `model.a isa Metric` failed; using default: a=Euclidean().") B1b(a=BhattacharyyaDist()).a isa Euclidean
+
+    @mlj_model mutable struct B1c
+        a::SemiMetric = Euclidean()
+    end
+    @test B1c().a isa Euclidean
+end

--- a/test/parameters_utils.jl
+++ b/test/parameters_utils.jl
@@ -1,92 +1,93 @@
+module TestMacroMLJ
+
 using MLJBase, Test, Distances
 using MLJModels: @mlj_model
 
-@testset "@mlj_model" begin
-    # No type, no default
-    @mlj_model mutable struct A1
-        a
-    end
-    a = A1()
-    @test ismissing(a.a)
-    a.a = 5
-    @test a.a == 5
-
-    # No type, with default
-    @mlj_model mutable struct A1b
-        a = 5
-    end
-    a = A1b()
-    @test a.a == 5
-    a.a = "hello"
-    @test a.a == "hello"
-
-    # If a type is given but no default value is given, then the macro tries to fill
-    # a default value; either 0 if it's a Number type, or an empty string and otherwise fails.
-    @mlj_model mutable struct A1c
-        a::Int
-    end
-    a = A1c()
-    @test a.a == 0
-    a = A1c(a=7)
-    @test a.a == 7
-    @test_throws InexactError A1c(a=5.3)
-    @test_throws MethodError A1c(a="hello")
-
-    # Type is given and default is given
-    @mlj_model mutable struct A1d
-        a::Int = 5
-    end
-    a = A1d()
-    @test a.a == 5
-    a = A1d(a=7)
-    @test a.a == 7
-
-    # No type is given but a default and constraint
-    @mlj_model mutable struct A1e
-        a = 5::(_ > 0)
-    end
-    a = A1e()
-    @test a.a == 5
-    a = A1e(a=7)
-    @test a.a == 7
-    @test @test_logs (:warn, "Constraint `model.a > 0` failed; using default: a=5.") A1e(a=-1).a==5
-    a = A1e(a=7.5)
-    @test a.a == 7.5
-
-    # Type is given with default and constraint
-    @mlj_model mutable struct A1f
-        a::Int = 5::(_ > 0)
-    end
-    a = A1f()
-    @test a.a == 5
-    a = A1f(a=7)
-    @test a.a == 7
-    @test_throws InexactError A1f(a=7.5)
-    @test @test_logs (:warn, "Constraint `model.a > 0` failed; using default: a=5.") A1f(a=-1).a==5
+# No type, no default
+@mlj_model mutable struct A1
+    a
 end
+a = A1()
+@test ismissing(a.a)
+a.a = 5
+@test a.a == 5
 
-
-@testset "@mlj_model - advanced" begin
-    abstract type FooBar end
-    @mlj_model mutable struct B1a <: FooBar
-        a::Symbol = :auto::(_ in (:auto, :semi))
-    end
-    b = B1a()
-    @test b.a == :auto
-    b = B1a(a=:semi)
-    @test b.a == :semi
-    @test @test_logs (:warn, "Constraint `model.a in (:auto, :semi)` failed; using default: a=:auto.") B1a(a=:autos).a == :auto
-    @test_throws MethodError B1a(b="blah")
-
-    # == dependence on other types
-    @mlj_model mutable struct B1b
-        a::SemiMetric = Euclidean()::(_ isa Metric)
-    end
-    @test B1b().a isa Euclidean
-    @test @test_logs (:warn, "Constraint `model.a isa Metric` failed; using default: a=Euclidean().") B1b(a=BhattacharyyaDist()).a isa Euclidean
-
-    @mlj_model mutable struct B1c
-        a::SemiMetric = Euclidean()
-    end
-    @test B1c().a isa Euclidean
+# No type, with default
+@mlj_model mutable struct A1b
+    a = 5
 end
+a = A1b()
+@test a.a == 5
+a.a = "hello"
+@test a.a == "hello"
+
+# If a type is given but no default value is given, then the macro tries to fill
+# a default value; either 0 if it's a Number type, or an empty string and otherwise fails.
+@mlj_model mutable struct A1c
+    a::Int
+end
+a = A1c()
+@test a.a == 0
+a = A1c(a=7)
+@test a.a == 7
+@test_throws InexactError A1c(a=5.3)
+@test_throws MethodError A1c(a="hello")
+
+# Type is given and default is given
+@mlj_model mutable struct A1d
+    a::Int = 5
+end
+a = A1d()
+@test a.a == 5
+a = A1d(a=7)
+@test a.a == 7
+
+# No type is given but a default and constraint
+@mlj_model mutable struct A1e
+    a = 5::(_ > 0)
+end
+a = A1e()
+@test a.a == 5
+a = A1e(a=7)
+@test a.a == 7
+@test @test_logs (:warn, "Constraint `model.a > 0` failed; using default: a=5.") A1e(a=-1).a==5
+a = A1e(a=7.5)
+@test a.a == 7.5
+
+# Type is given with default and constraint
+@mlj_model mutable struct A1f
+    a::Int = 5::(_ > 0)
+end
+a = A1f()
+@test a.a == 5
+a = A1f(a=7)
+@test a.a == 7
+@test_throws InexactError A1f(a=7.5)
+@test @test_logs (:warn, "Constraint `model.a > 0` failed; using default: a=5.") A1f(a=-1).a==5
+
+abstract type FooBar end
+@mlj_model mutable struct B1a <: FooBar
+    a::Symbol = :auto::(_ in (:auto, :semi))
+end
+b = B1a()
+@test b.a == :auto
+b = B1a(a=:semi)
+@test b.a == :semi
+@test @test_logs (:warn, "Constraint `model.a in (:auto, :semi)` failed; using default: a=:auto.") B1a(a=:autos).a == :auto
+@test_throws MethodError B1a(b="blah")
+
+# == dependence on other types
+@mlj_model mutable struct B1b
+    a::SemiMetric = Euclidean()::(_ isa Metric)
+end
+@test B1b().a isa Euclidean
+@test @test_logs (:warn, "Constraint `model.a isa Metric` failed; using default: a=Euclidean().") B1b(a=BhattacharyyaDist()).a isa Euclidean
+
+@mlj_model mutable struct B1c
+    a::SemiMetric = Euclidean()
+end
+@test B1c().a isa Euclidean
+
+
+end
+true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,8 @@ end
 
 end
 
+include("parameters_utils.jl")
+
 @testset "MultivariateStats  " begin
     @test include("MultivariateStats.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,9 @@ end
 
 end
 
-include("parameters_utils.jl")
+@testset "@mlj_model macro" begin
+    include("parameters_utils.jl")
+end
 
 @testset "MultivariateStats  " begin
     @test include("MultivariateStats.jl")


### PR DESCRIPTION
I believe this closes #53 

* addition of a `@mlj_model` macro, this is essentially similar to `@with_kw` except it includes the call to `clean!`, it's heavily inspired from the `@sk_model` macro though I tested it quite a bit and had to tweak a number of things to have it work robustly. 
* it also fixes a minor typo in the `sk_model` macro which could have caused issue (`ff` instead of `f`)
* this is now used in `Clustering`, `NearestNeighbors` and `MultivariateStats` (as per this PR)

**Note**: this is a very convenient way to quickly define the structs but it shouldn't be used everywhere. In particular it's currently not appropriate if the struct must be a parametric one. Also if the clean method is trivial, it's not necessary to use this. 

~~**Note**: currently passing apart from 1.0 (🙄) will need to see how I can bypass this...~~

The issue mentioned in #53 works fine (on MLJ dev, and this branch of MLJModels):

```julia
julia> X, y = @load_iris;
julia> model = @load KNNClassifier
KNNClassifier(K = 5,
              algorithm = :kdtree,
              metric = Distances.Euclidean(0.0),
              leafsize = 10,
              reorder = true,
              weights = :uniform,) @ 1…93

julia> mach = machine(model, X, y)
Machine{KNNClassifier} @ 7…60

julia> fit!(mach)
[ Info: Training Machine{KNNClassifier} @ 7…60.
Machine{KNNClassifier} @ 7…60

julia> model2 = KNNClassifier(metric=Cityblock())
KNNClassifier(K = 5,
              algorithm = :kdtree,
              metric = Cityblock(),
              leafsize = 10,
              reorder = true,
              weights = :uniform,) @ 9…85

julia> mach2 = machine(model2, X, y)
Machine{KNNClassifier} @ 1…72

julia> fit!(mach2)
[ Info: Training Machine{KNNClassifier} @ 1…72.
Machine{KNNClassifier} @ 1…72

```