### PR TITLE
Defmacros

### DIFF
--- a/src/ScikitLearn/ScikitLearn.jl
+++ b/src/ScikitLearn/ScikitLearn.jl
@@ -22,7 +22,57 @@ import ..ScikitLearn
 
 include("svm.jl")
 
-import .._unpack!
+import .._process_model_def, .._model_constructor, .._model_cleaner
+
+"""
+_skmodel_fit
+
+Called as part of [`@sk_model`](@ref), returns the expression corresponing to the `fit` method
+for the ScikitLearn model.
+"""
+function _skmodel_fit(modelname, params)
+	quote
+		function MLJBase.fit(model::$modelname, verbosity::Int, X, y)
+			# body of the function
+			Xmatrix   = MLJBase.matrix(X)
+			yplain    = y
+			targnames = nothing
+			# in multi-target case
+			if Tables.istable(y)
+			   yplain    = MLJBase.matrix(y)
+			   targnames = MLJBase.schema(y).names
+			end
+			# Call the parent constructor from Sklearn.jl named Model_
+			skmodel = $(Symbol(modelname, "_"))($((Expr(:kw, p, :(model.$p)) for p in params)...))
+			fitres  = ScikitLearn.fit!(skmodel, Xmatrix, yplain)
+			# TODO: we may want to use the report later on
+			report  = NamedTuple()
+			return ((fitres, targnames), nothing, report)
+		end
+	end
+end
+
+
+"""
+_skmodel_predict
+
+Called as part of [`@sk_model`](@ref), returns the expression corresponing to the `predict` method
+for the ScikitLearn model.
+"""
+function _skmodel_predict(modelname)
+	quote
+		function MLJBase.predict(model::$modelname, (fitresult, targnames), Xnew)
+			Xmatrix = MLJBase.matrix(Xnew)
+			preds   = ScikitLearn.predict(fitresult, Xmatrix)
+			if isa(preds, Matrix)
+				# build a table with the appropriate column names
+				preds = MLJBase.table(preds, names=targnames)
+			end
+			return preds
+		end
+	end
+end
+
 
 
 """
@@ -39,119 +89,37 @@ end
 MLJBase.fit and MLJBase.predict methods are also produced.
 """
 macro sk_model(ex)
-    # pull out defaults and constraints
-    defaults 	= Dict()
-    constraints = Dict()
-    Model 		= ex.args[2] isa Symbol ? ex.args[2] : ex.args[2].args[1]
-    fnames 		= Symbol[]
-
-    for i = 1:length(ex.args[3].args)
-        f = ex.args[3].args[i]
-        f isa LineNumberNode && continue
-
-        fname, ftype = f.args[1] isa Symbol ?
-                            (f.args[1], :Any) :
-                            (f.args[1].args[1], f.args[1].args[2])
-        push!(fnames, fname)
-
-        if f.head == :(=)
-            default = f.args[2]
-            if default isa Expr
-                constraints[fname] = default.args[2]
-                default = default.args[1]
-            end
-            defaults[fname] = default
-            ex.args[3].args[i] = f.args[1]
-        end
-    end
-
-    # make kw constructor which calls the clean! function
-    const_ex = Expr(:function, Expr(:call, Model, Expr(:parameters,
-     	                  [Expr(:kw, fname, defaults[fname]) for fname in fnames]...)),
-                    # body of the function
-                    Expr(:block,
-                         Expr(:(=), :model, Expr(:call, :new, [fname for fname in fnames]...)),
-                         :(message = MLJBase.clean!(model)),
-            			 :(isempty(message) || @warn message),
-            			 :(return model)
-        				 )
-    			 	)
+	# similar to @mlj_model
+    ex, modelname, params, defaults, constraints = _process_model_def(ex)
+	# keyword constructor
+    const_ex = _model_constructor(modelname, params, defaults)
+	# associate the constructor with the definition of the struct
     push!(ex.args[3].args, const_ex)
+	# cleaner
+    clean_ex = _model_cleaner(modelname, defaults, constraints)
 
-    # add fit function
-    fit_ex = :(function MLJBase.fit(model::$Model, verbosity::Int, X, y)
-                   # body of the function
-                   Xmatrix    = MLJBase.matrix(X)
-                   yplain     = y
-                   targ_names = nothing
-                   # in multi-target case
-                   if Tables.istable(y)
-                       yplain     = MLJBase.matrix(y)
-                       targ_names = MLJBase.schema(y).names
-                   end
-                   cache     = $(Symbol(Model, "_"))($([Expr(:kw, fname, :(model.$fname))
-                                                            for fname in fnames]...))
-                   result    = ScikitLearn.fit!(cache, Xmatrix, yplain)
-                   fitresult = result
-                   # TODO: we may want to use the report later on
-                   report    = NamedTuple()
-                   return ((fitresult, targ_names), nothing, report)
-               end)
+	# here starts the differences with the `@mlj_model` macro: addition of an
+	# automatically defined `fit` and `predict` method
+	fit_ex 	   = _skmodel_fit(modelname, params)
+	predict_ex = _skmodel_predict(modelname)
 
-    # clean function
-    clean_ex = Expr(:function, :(MLJBase.clean!(model::$Model)),
-                    # body of the function
-                    Expr(:block,
-                         :(warning = ""),
-                         # condition and action for each constraint
-                         # each parameter is given as field::Type = default::constraint
-                         # here we recuperate the constraint and express it as an if statement
-                         # for instance if we had
-                         #     alpha::Real = 0.0::(arg > 0.0)
-                         # this would become
-                         #     if !(alpha > 0.0)
-        				 [Expr(:if, Expr(:call, :!, _unpack!(constr, :(model.$param))),
-                               # action of the constraint is violated:
-                               # add a message and use default for the parameter
-        				       Expr(:block,
-                                    :(warning *= $("constraint ($constr) failed; using default: $param=$(defaults[param]).\n")),
-                                    :(model.$param = $(defaults[param]))
-                                    )
-                               ) for (param, constr) in constraints]...,
-                         # return full message
-        				 :(return warning)
-                        )
-                    )
-    # predict function
-    predict_ex = Expr(:function, :(MLJBase.predict(model::$Model, (fitresult, targ_names), Xnew)),
-                    # body of the predict function
-        			Expr(:block,
-                         :(xnew  = MLJBase.matrix(Xnew)),
-                         :(preds = ScikitLearn.predict(fitresult, xnew)),
-                         :(isa(preds, Matrix) && (preds = MLJBase.table(preds, names=targ_names))),
-                         :(return preds)
-                         ) )
-
-    # model metadata note that it does not assign scitypes etc, these have
-    # to be added manually model by model.
-    # --> input_scitype
-    # --> target_scitype
-    Model_str = string(Model)
+	mdl = modelname
     esc(
-        quote
-        export $Model
-        $ex
-        $fit_ex
-        $clean_ex
-        $predict_ex
-        MLJBase.load_path(::Type{<:$Model})       = string("MLJModels.ScikitLearn_.", $Model_str)
-        MLJBase.package_name(::Type{<:$Model})    = "ScikitLearn"
-        MLJBase.package_uuid(::Type{<:$Model})    = "3646fa90-6ef7-5e7e-9f22-8aca16db6324"
-        MLJBase.is_pure_julia(::Type{<:$Model})   = false
-        MLJBase.package_url(::Type{<:$Model})     = "https://github.com/cstjean/ScikitLearn.jl"
-        MLJBase.package_license(::Type{<:$Model}) = "BSD"
-        end
-    )
+		quote
+			# Base.@__doc__ $ex
+	        export $modelname
+	        $ex
+	        $fit_ex
+	        $clean_ex
+	        $predict_ex
+	        MLJBase.load_path(::Type{<:$mdl}) 		= "MLJModels.ScikitLearn_.$mdl"
+	        MLJBase.package_name(::Type{<:$mdl})    = "ScikitLearn"
+	        MLJBase.package_uuid(::Type{<:$mdl})    = "3646fa90-6ef7-5e7e-9f22-8aca16db6324"
+	        MLJBase.is_pure_julia(::Type{<:$mdl})   = false
+	        MLJBase.package_url(::Type{<:$mdl})     = "https://github.com/cstjean/ScikitLearn.jl"
+	        MLJBase.package_license(::Type{<:$mdl}) = "BSD"
+	    end
+	)
 end
 
 include("linear-regressors.jl")

--- a/src/parameters_utils.jl
+++ b/src/parameters_utils.jl
@@ -8,6 +8,87 @@
 import Base: @__doc__
 
 """
+_process_model_def(ex)
+
+Take an expression defining a model (`mutable struct Model ...`) and unpack key elements for
+further processing:
+
+- Model name (`modelname`)
+- Names of parameters (`params`)
+- Default values (`defaults`)
+- Constraints (`constraints`)
+"""
+function _process_model_def(ex)
+    defaults    = Dict{Symbol,Any}()
+    constraints = Dict{Symbol,Any}()
+    modelname   = ex.args[2] isa Symbol ? ex.args[2] : ex.args[2].args[1]
+    params      = Symbol[]
+
+    # inspect all lines which may define parameters, retrieve their names,
+    # default values and constraints on values that can be given to them
+    for i in 1:length(ex.args[3].args)
+        # retrieve meaningful lines
+        line = ex.args[3].args[i]
+        line isa LineNumberNode && continue
+
+        # line without information (e.g. just a name "a")
+        if line isa Symbol
+            param = line
+            push!(params, param)
+            defaults[param] = missing
+        else
+            # A meaningful line will look like
+            #   line.args[1] = line.args[2]
+            #
+            # where line.args[1] will either be just `name`  or `name::Type`
+            # and   line.args[2] will either be just `value` or `value::constraint`
+            # ---------------------------------------------------------
+            # 1. decompose `line.args[1]` appropriately (name and type)
+            if line.args[1] isa Symbol # case :a
+                param = line.args[1]
+                type  = length(line.args) > 1 ? line.args[2] : :Any
+            else                       # case :(a::Int)
+                param, type = line.args[1].args[1:2] # (:a, Int)
+            end
+            push!(params, param)
+            # ------------------------------------------------------------------
+            # 2. decompose `line.args[2]` appropriately (values and constraints)
+            if line.head == :(=) # assignment for default
+                default = line.args[2]
+                # if a constraint is given (value::constraint)
+                if default isa Expr && length(default.args) > 1
+                    constraints[param] = default.args[2]
+                    # now discard the constraint to keep only the value
+                    default = default.args[1]
+                end
+                defaults[param]    = default       # this will be a value not an expr
+                ex.args[3].args[i] = line.args[1]  # name or name::Type (for the constructor)
+            else
+                # these are simple heuristics when no default value is given for the
+                # field but an "obvious" one can be provided implicitly (ideally this should
+                # not be used as it's not very clear that the intention matches the usage)
+                eff_type = eval(type)
+                if eff_type <: Number
+                    defaults[param] = zero(eff_type)
+                elseif eff_type <: AbstractString
+                    defaults[param] = ""
+                elseif eff_type == Any         # e.g. Any or no type given
+                    defaults[param] = missing
+                elseif eff_type >: Nothing     # e.g. Union{Nothing, ...}
+                    defaults[param] = nothing
+                elseif eff_type >: Missing     # e.g. Union{Missing, ...} (unlikely)
+                    defaults[param] = missing
+                else
+                    @error "A default value for parameter '$param' (type '$type') must be given"
+                end
+            end
+        end
+    end
+    return ex, modelname, params, defaults, constraints
+end
+
+
+"""
 _unpack!(ex, rep)
 
 Internal function to allow to read a constraint given after a default value for a parameter
@@ -31,125 +112,74 @@ _unpack!(ex, _) = ex # when it's been unpacked, it's not an expression anymore
 
 
 """
+_model_constructor(modelname, params, defaults)
+
+Build the expression of the keyword constructor associated with a model definition.
+When the constructor is called, the `MLJBase.clean!` function is called as well to check that
+parameter assignments are valid.
+"""
+function _model_constructor(modelname, params, defaults)
+    Expr(:function, Expr(:call, modelname, Expr(:parameters, (Expr(:kw, p, defaults[p]) for p in params)...)),
+        # body of the function
+        Expr(:block,
+             Expr(:(=), :model, Expr(:call, :new, params...)),
+             :(message = MLJBase.clean!(model)),
+			 :(isempty(message) || @warn message),
+			 :(return model)
+			 )
+	 	)
+end
+
+"""
+_model_cleaner(modelname, defaults, constraints)
+
+Build the expression of the cleaner associated with the constraints specified in a model def.
+"""
+function _model_cleaner(modelname, defaults, constraints)
+    Expr(:function, :(MLJBase.clean!(model::$modelname)),
+        # body of the function
+        Expr(:block,
+             :(warning = ""),
+             # condition and action for each constraint
+             # each parameter is given as field::Type = default::constraint
+             # here we recuperate the constraint and express it as an if statement
+             # for instance if we had
+             #     alpha::Real = 0.0::(arg > 0.0)
+             # this would become
+             #     if !(alpha > 0.0)
+             (Expr(:if, Expr(:call, :!, _unpack!(constr, :(model.$param))),
+                   # action of the constraint is violated:
+                   # add a message and use default for the parameter
+                   Expr(:block,
+                        :(warning *= $("Constraint `$constr` failed; using default: $param=$(defaults[param]).")),
+                        :(model.$param = $(defaults[param]))
+                        )
+                   ) for (param, constr) in constraints)...,
+             # return full message
+             :(return warning)
+            )
+        )
+end
+
+
+"""
 mlj_model
 
 Macro to help define MLJ models with constraints on the default parameters, this can be seen as
 a tweaked version of the `@with_kw` macro from `Parameters`.
 """
 macro mlj_model(ex)
-    # pull out defaults and constraints
-    defaults    = Dict{Symbol,Any}()
-    constraints = Dict{Symbol,Any}()
-    # name of the model
-    Model = ex.args[2] isa Symbol ? ex.args[2] : ex.args[2].args[1]
-
-    # inspect all fields, retrieve the names and the constraints
-    fnames = Symbol[]
-    for i in 1:length(ex.args[3].args)
-        # retrieve meaningful lines
-        f = ex.args[3].args[i]
-        f isa LineNumberNode && continue
-
-        # line without information (e.g. just a name "param")
-        if f isa Symbol
-            push!(fnames, f)
-            defaults[f] = missing
-        else
-            # A meaningful line will look like
-            #   f.args[1] = f.args[2]
-            #
-            # where f.args[1] will either be just `name`  or `name::Type`
-            # and   f.args[2] will either be just `value` or `value::constraint`
-
-            # -- decompose `f.args[1]` appropriately to retrieve the field name
-
-            if f.args[1] isa Symbol
-                # :a
-                fname = f.args[1]
-                ftype = length(f.args)>1 ? f.args[2] : :Any
-            else
-                # :(a::Int)
-                fname, ftype = f.args[1].args[1:2]
-            end
-            push!(fnames, fname)
-
-            # -- decompose `f.args[2]` appropriately to retrieve the value and constraint
-
-            if f.head == :(=) # assignment for default
-                default = f.args[2]
-                # if a constraint is given (value::constraint)
-                if default isa Expr
-                    if length(default.args) > 1
-                        constraints[fname] = default.args[2] # constraint
-                        default = default.args[1]
-                    end
-                end
-                defaults[fname]    = default    # this will be a value not an expr
-                ex.args[3].args[i] = f.args[1]  # name or name::Type (for the constructor)
-            else
-                # these are simple heuristics when no default value is given for the
-                # field but an "obvious" one can be provided implicitly (ideally this
-                # should not be used as it's not very clear that the intention matches the usage)
-                eff_ftype = eval(ftype)
-                if eff_ftype <: Number
-                    defaults[fname] = zero(eff_ftype)
-                elseif eff_ftype <: AbstractString
-                    defaults[fname] = ""
-                elseif eff_type == Any          # e.g. Any or no type given
-                    defaults[fname] = nothing
-                elseif eff_type >: Nothing      # e.g. Union{Nothing, ...}
-                    defaults[fname] = nothing
-                elseif eff_ftype >: Missing     # e.g. Union{Missing, ...} (unlikely)
-                    defaults[fname] = missing
-                else
-                    @error "A default value for parameter '$fname' of type '$ftype' must be " *
-                           "provided."
-                end
-            end
-        end
-    end
-
-    # Build the kw constructor
-    const_ex = Expr(:function, Expr(:call, Model, Expr(:parameters,
-     	                  [Expr(:kw, fname, defaults[fname]) for fname in fnames]...)),
-                    # body of the function
-                    Expr(:block,
-                         Expr(:(=), :model, Expr(:call, :new, [fname for fname in fnames]...)),
-                         :(message = MLJBase.clean!(model)),
-            			 :(isempty(message) || @warn message),
-            			 :(return model)
-        				 )
-    			 	)
+    ex, modelname, params, defaults, constraints = _process_model_def(ex)
+	# keyword constructor
+    const_ex = _model_constructor(modelname, params, defaults)
+	# associate the constructor with the definition of the struct
     push!(ex.args[3].args, const_ex)
-
-    clean_ex = Expr(:function, :(MLJBase.clean!(model::$Model)),
-                # body of the function
-                Expr(:block,
-                     :(warning = ""),
-                     # condition and action for each constraint
-                     # each parameter is given as field::Type = default::constraint
-                     # here we recuperate the constraint and express it as an if statement
-                     # for instance if we had
-                     #     alpha::Real = 0.0::(arg > 0.0)
-                     # this would become
-                     #     if !(alpha > 0.0)
-                     [Expr(:if, Expr(:call, :!, _unpack!(constr, :(model.$param))),
-                           # action of the constraint is violated:
-                           # add a message and use default for the parameter
-                           Expr(:block,
-                                :(warning *= $("Constraint `$constr` failed; using default: $param=$(defaults[param]).")),
-                                :(model.$param = $(defaults[param]))
-                                )
-                           ) for (param, constr) in constraints]...,
-                     # return full message
-                     :(return warning)
-                    )
-                )
-
+	# cleaner
+    clean_ex = _model_cleaner(modelname, defaults, constraints)
     esc(
         quote
             Base.@__doc__ $ex
-            export $Model
+            export $modelname
             $ex
             $clean_ex
         end

--- a/src/parameters_utils.jl
+++ b/src/parameters_utils.jl
@@ -18,17 +18,16 @@ For instance if we have
 
 Then it would transform the `(arg > 0.0)` in `(alpha > 0.0)` which is executable.
 """
-function _unpack!(ex, rep)
-    if ex isa Expr
-        for i in eachindex(ex.args)
-            if ex.args[i] ∈ (:_, :arg)
-                ex.args[i] = rep
-            end
-            _unpack!(ex.args[i], rep)
+function _unpack!(ex::Expr, rep)
+    for i in eachindex(ex.args)
+        if ex.args[i] ∈ (:_, :arg)
+            ex.args[i] = rep
         end
+        _unpack!(ex.args[i], rep)
     end
     return ex
 end
+_unpack!(ex, _) = ex # when it's been unpacked, it's not an expression anymore
 
 
 """


### PR DESCRIPTION
This generally improves the macros `@mlj_model` and `sk_model` by

* extracting the different bits into _functions_ which are now called within the macros, this makes it a lot easier to reason about the macros and to maintain them
* macros are now reduced to the bare minimum calling those functions, this means that both macros are now  "in synch" (they call the same functions initially) which is good for maintenance

It now becomes easier to envisage extending the `@sk_model` macro for classifiers. In much the same way as the functions `_skmodel_predict` is defined, there would be a `_skmodel_predict_proba`. One of the two would be loaded conditional on whether the expression contains a `<: Probabilistic` or `<: Deterministic`. This is wip on branch `skc`.

Anyway I wanted to get this through this before any work to migrate code to MLJBase was done (#56) 

I don't think an in-depth review is required but I'll leave this open until tomorrow in case there are comments and will otherwise merge.