### PR TITLE
using Tables.schema instead of MLJBase.schema when only needing names

### DIFF
--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -16,6 +16,7 @@ module GLM_
 import MLJBase
 import Distributions
 using Parameters
+using Tables
 
 import ..GLM
 
@@ -83,7 +84,7 @@ const GLM_MODELS = Union{<:LinearRegressor, <:LinearBinaryClassifier, <:LinearCo
 
 function MLJBase.fit(model::LinearRegressor, verbosity::Int, X, y)
 	# apply the model
-	features  = MLJBase.schema(X).names
+	features  = Tables.schema(X).names
 	Xmatrix   = augment_X(MLJBase.matrix(X), model.fit_intercept)
 	fitresult = GLM.glm(Xmatrix, y, Distributions.Normal(), GLM.IdentityLink())
 	# form the report
@@ -95,7 +96,7 @@ end
 
 function MLJBase.fit(model::LinearCountRegressor, verbosity::Int, X, y)
 	# apply the model
-	features  = MLJBase.schema(X).names
+	features  = Tables.schema(X).names
 	Xmatrix   = augment_X(MLJBase.matrix(X), model.fit_intercept)
 	fitresult = GLM.glm(Xmatrix, y, model.distribution, model.link)
 	# form the report
@@ -107,7 +108,7 @@ end
 
 function MLJBase.fit(model::LinearBinaryClassifier, verbosity::Int, X, y)
 	# apply the model
-	features  = MLJBase.schema(X).names
+	features  = Tables.schema(X).names
 	Xmatrix   = augment_X(MLJBase.matrix(X), model.fit_intercept)
 	decode    = y[1]
 	y_plain   = MLJBase.int(y) .- 1 # 0, 1 of type Int

--- a/src/MultivariateStats.jl
+++ b/src/MultivariateStats.jl
@@ -4,6 +4,7 @@ export RidgeRegressor, PCA, KernelPCA, ICA
 
 import MLJBase
 using ScientificTypes
+using Tables
 
 import ..MultivariateStats # lazy loading
 
@@ -30,7 +31,7 @@ function MLJBase.fit(model::RidgeRegressor,
                      y)
 
     Xmatrix = MLJBase.matrix(X)
-    features = MLJBase.schema(X).names
+    features = Tables.schema(X).names
 
     weights = MS.ridge(Xmatrix, y, model.lambda)
 

--- a/src/ScikitLearn/ScikitLearn.jl
+++ b/src/ScikitLearn/ScikitLearn.jl
@@ -7,6 +7,7 @@ using Tables
 
 #> for all classifiers:
 using CategoricalArrays
+using Tables
 
 # NOTE: legacy code for SVM models does not use the @sk_model macro.
 
@@ -53,7 +54,7 @@ function _skmodel_fit_reg(modelname, params)
 			# can be named accordingly
 			if Tables.istable(y)
 			   yplain    = MLJBase.matrix(y)
-			   targnames = MLJBase.schema(y).names
+			   targnames = Tables.schema(y).names
 			end
 			# Call the parent constructor from Sklearn.jl named $modelname_
 			skmodel = $(Symbol(modelname, "_"))($((Expr(:kw, p, :(model.$p)) for p in params)...))

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -71,7 +71,7 @@ end
 FeatureSelector(;features=Symbol[]) = FeatureSelector(features)
 
 function fit(transformer::FeatureSelector, verbosity::Int, X)
-    namesX = MLJBase.schema(X).names
+    namesX = Tables.schema(X).names
     issubset(Set(transformer.features), Set(namesX)) ||
         throw(error("Attempting to select non-existent feature(s)."))
     if isempty(transformer.features)
@@ -86,7 +86,7 @@ end
 MLJBase.fitted_params(::FeatureSelector, fitresult) = (features_to_keep=fitresult,)
 
 function transform(transformer::FeatureSelector, features, X)
-    issubset(Set(features), Set(MLJBase.schema(X).names)) ||
+    issubset(Set(features), Set(Tables.schema(X).names)) ||
         throw(error("Supplied frame does not admit previously selected features."))
     return MLJBase.selectcols(X, features)
 end

--- a/test/ScikitLearn/linear-regressors.jl
+++ b/test/ScikitLearn/linear-regressors.jl
@@ -252,7 +252,7 @@ y2 = (t1=y, t2=y)
     @test keys(fp) == (:coef, :intercept)
     pred = predict(m, f, X)
     @test pred isa Tables.MatrixTable
-    @test MLJBase.schema(pred).names == (:t1, :t2)
+    @test Tables.schema(pred).names == (:t1, :t2)
 end
 
 @testset "MTLassoCV" begin

--- a/test/Transformers.jl
+++ b/test/Transformers.jl
@@ -71,7 +71,7 @@ fitresult, cache, report = MLJBase.fit(stand, 1, X)
 Xnew = transform(stand, fitresult, X)
 
 fitresult, cache, report = MLJBase.fit(stand, 1, X)
-@test issubset(Set(keys(fitresult)), Set(MLJBase.schema(X).names[[5,]]))
+@test issubset(Set(keys(fitresult)), Set(Tables.schema(X).names[[5,]]))
 transform(stand, fitresult, X)
 @test Xnew[1] == X[1]
 @test Xnew[2] == X[2]
@@ -133,8 +133,8 @@ Xtsmall = transform(t, fitresult_small, X)
 t = OneHotEncoder(ordered_factor=false)
 fitresult, cache, _ = MLJBase.fit(t, 1, X)
 Xt = transform(t, fitresult, X)
-@test :name in MLJBase.schema(Xt).names
-@test :favourite_number__5 in MLJBase.schema(Xt).names
+@test :name in Tables.schema(Xt).names
+@test :favourite_number__5 in Tables.schema(Xt).names
 
 # test that one may not add new columns:
 X = (name=categorical(["Ben", "John", "Mary", "John"], ordered=true),


### PR DESCRIPTION
this is a simple fix which I'll merge assuming all tests pass (no reason they wouldn't). 

Tables is already a dependency anyway so it really only avoids unnecessary computations. Later on we may rever this if we do want to access the extra field provided by MLJBase in the `fit` mechanism, that will be easy to revert.