### PR TITLE
removing clean method in nearestneighbors and pass a python seed to s…

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -70,32 +70,6 @@ end
 
 const KNN = Union{KNNRegressor, KNNClassifier}
 
-function MLJBase.clean!(m::KNN)
-    warning = ""
-    if m.K < 1
-        warning *= "Number of neighbors 'K' needs to be larger than 0. Setting to 1.\n"
-        m.K = 1
-    end
-    if m.leafsize < 0
-        warning *= "Leaf size should be ≥ 0. Setting to 10.\n"
-        m.leafsize = 10
-    end
-    if m.algorithm ∉ (:kdtree, :brutetree, :balltree)
-        warning *= "The tree algorithm should be ':kdtree', ':brutetree' or ':balltree'." *
-                   "Setting to ':kdtree'.\n"
-        m.algorithm = :kdtree
-    end
-    if m.algorithm == :kdtree && !isa(m.metric ∉ (Euclidean, Chebyshev, Minkowski, Citiblock))
-        warning *= "KDTree only supports axis-aligned metrics. Setting to 'Euclidean'.\n"
-        m.metric = Euclidean()
-    end
-    if m.weights ∉ (:uniform, :distance)
-        warning *= "Weighing should be ':uniform' or ':distance'. Setting to ':uniform'.\n"
-        m.weights = :distance
-    end
-    return warning
-end
-
 function MLJBase.fit(m::KNN, verbosity::Int, X, y)
     Xmatrix = MLJBase.matrix(X, transpose=true) # NOTE: copies the data
     if m.algorithm == :kdtree

--- a/test/ScikitLearn/linear-classifiers.jl
+++ b/test/ScikitLearn/linear-classifiers.jl
@@ -71,6 +71,7 @@ end
 
 # NOTE: SGD classifier with few points is tricky which is why we remove the dummy test
 @testset "SGDClf" begin
+    ((ScikitLearn.Skcore).pyimport("numpy.random")).seed(0)
     m, f = simple_test_classif(SGDClassifier(), Xc2, yc2; nodummy=true)
     fp = fitted_params(m, f)
     @test keys(fp) == (:coef, :intercept)
@@ -78,7 +79,7 @@ end
     @test infos[:input_scitype] == MLJBase.Table(MLJBase.Continuous)
     @test infos[:target_scitype] == AbstractVector{<:MLJBase.Finite}
     @test !isempty(infos[:docstring])
-
+    ((ScikitLearn.Skcore).pyimport("numpy.random")).seed(0)
     m, f = simple_test_classif_prob(ProbabilisticSGDClassifier(), Xc2, yc2; nodummy=true)
     fp = fitted_params(m, f)
     @test keys(fp) == (:coef, :intercept)


### PR DESCRIPTION
* removes the `clean!` method in nearestneighbors (raised by https://github.com/alan-turing-institute/MLJModels.jl/pull/69#issuecomment-535377695) 
* pass a python seed to the SGD classifier to avoid spurious failures due to SGD being random
