### PR TITLE
Resolve DecistionTree incompatibility (#77)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.5.0"
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -23,12 +22,12 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-DecisionTree = "0.8"
 MLJBase = "0.6"
 julia = "1"
 
 [extras]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
+DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 GaussianProcesses = "891a1506-143c-57d2-908e-e1f8e92e6de9"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
@@ -41,4 +40,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [targets]
-test = ["Clustering", "GLM", "GaussianProcesses", "LIBSVM", "MultivariateStats", "NaiveBayes", "NearestNeighbors", "ScikitLearn", "RDatasets", "Test", "XGBoost"]
+test = ["Clustering", "DecisionTree", "GLM", "GaussianProcesses", "LIBSVM", "MultivariateStats", "NaiveBayes", "NearestNeighbors", "ScikitLearn", "RDatasets", "Test", "XGBoost"]

--- a/test/DecisionTree.jl
+++ b/test/DecisionTree.jl
@@ -7,7 +7,7 @@ using MLJBase
 
 # load code to be tested:
 import MLJModels
-import DecisionTree 
+import DecisionTree
 using MLJModels.DecisionTree_
 
 # get some test data:
@@ -19,9 +19,10 @@ const y = iris[:, 5]
 baretree = DecisionTreeClassifier()
 
 baretree.max_depth = 1
-fitresult, cache, report = MLJBase.fit(baretree, 1, X, y);
+fitresult, cache, report = MLJBase.fit(baretree, 2, X, y);
 baretree.max_depth = -1 # no max depth
-fitresult, cache, report = MLJBase.update(baretree, 1, fitresult, cache, X, y);
+fitresult, cache, report =
+    MLJBase.update(baretree, 1, fitresult, cache, X, y);
 
 # in this case decision tree is a perfect predictor:
 yhat = MLJBase.predict_mode(baretree, fitresult, X);
@@ -30,7 +31,8 @@ yhat = MLJBase.predict_mode(baretree, fitresult, X);
 # but pruning upsets this:
 baretree.post_prune = true
 baretree.merge_purity_threshold=0.1
-fitresult, cache, report = MLJBase.update(baretree, 2, fitresult, cache, X, y)
+fitresult, cache, report =
+    MLJBase.update(baretree, 2, fitresult, cache, X, y)
 yhat = MLJBase.predict_mode(baretree, fitresult, X);
 @test yhat != y
 yhat = MLJBase.predict(baretree, fitresult, X);


### PR DESCRIPTION
It seems passing categorical elements into DecisionTreeClassfier causes problems with the new Multithreaded version. Instead we now pass integer-encoded targets in the way we do in most other classifiers, which is more performant anyhow. The only downside is that the "pretty tree" printouts you get by setting verbosity>1 refer to encoded levels not original levels. To address this we now return the encoding as part of the output of `fitted_params`. 