### PR TITLE
add Compat so as to pin it to version 2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.5.9"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -23,6 +24,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CategoricalArrays = "^0.7"
+Compat = "^2"
 Distances = "^0.8"
 Distributions = "^0.21"
 MLJBase = "^0.8.4"


### PR DESCRIPTION
This is hack until we figure out why Compat 3.0 is breaking testing of LIBSVM and NaiveBayes and what to do about it.