### PR TITLE
Add EvoTrees. For 0.8.1 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModels"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModels"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.9.0"
+version = "0.8.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/README.md
+++ b/README.md
@@ -2,322 +2,89 @@
 
 [![Build Status](https://travis-ci.com/alan-turing-institute/MLJModels.jl.svg?branch=master)](https://travis-ci.com/alan-turing-institute/MLJModels.jl)
 
-Repository of some [MLJ](https://github.com/alan-turing-institute/MLJ.jl)
-model _interfaces_, as well as the **MLJ model registry**.
+Repository of selected
+[MLJ](https://github.com/alan-turing-institute/MLJ.jl) model
+interfaces, and home of the MLJ model registry.
 
-## About
+### Contents
 
-This repository contains interfaces for a few "essential" Julia ML packages which do not yet provide their native interface to MLJ.
-It also provides a few "built-in" models, such as basic transformers (One Hot Encoder, Standardizer, ...).
+ - [Who is this repo for?](#who-is-this-repo-for)
+ - [What's provided here?](#what-is-provided-here)
+ - [Instructions for updating the MLJ model registry](#instructions-for-updating-the-mlj-model-registry)
 
-You can do `using MLJ` or `using MLJModels` and:
+## Who is this repo for?
+
+General users of the MLJ machine learning platform should refer to
+[MLJ home page](https://github.com/alan-turing-institute/MLJ.jl) for
+usage and installation instructions. While MLJ users are required to
+have MLJModels installed in their project environment, they can
+otherwise ignore it.
+
+This repository is for developers wishing to: 
+
+- add a model interface for a third party package that does not provide, or is
+  not willing to provide, an MLJ interface natively
+  
+- [register](#instructions-for-updating-the-mlj-model-registry) new
+  MLJ interfaces, whether they be defined here or in a third party
+  package
+
+To list *all* model interfaces currently registered, do `using MLJ` or `using MLJModels` and run:
 
 - `localmodels()` to list built-in models (updated when external models are loaded with `@load`)
+
 - `models()` to list all registered models, or see [this list](/src/registry/Models.toml).
 
-MLJModels houses the MLJ **model registry**: the list of models that can be called from MLJ using `@load`.
-Package developers can register new models by implementing the MLJ interface in their package and following the instructions below.
-
-## Writing an interface to MLJ
-
-In the instructions below, we assume you have a **registered** package `YourPackage.jl` which implements some models; that you would like to register these models with MLJ, and that you have a rough understanding of how things work with MLJ.
-In particular you are expected to be familiar with
-
-* what [Scientific Types](https://github.com/alan-turing-institute/ScientificTypes.jl) are
-* what `Probabilistic`, `Deterministic` and `Unsupervised` models are
-* the fact that MLJ generally works with tables rather than bare bone
-  matrices. Here a *table* is a container satisfying the
-  [Tables.jl](https://github.com/JuliaData/Tables.jl) API (e.g., DataFrame, JuliaDB table, CSV file, named tuple of equi-length vectors)
-* [CategoricalArrays.jl](https://github.com/JuliaData/CategoricalArrays.jl) (if working with finite discrete data)
-
-If you're not familiar with any one of these points, please refer to the general [MLJ docs](https://alan-turing-institute.github.io/MLJ.jl/dev/) and specifically, read the [detailed documentation](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Adding-Models-for-General-Use-1) for adding models.
-
-*But tables don't make sense for my model!* If a case can be made that
-tabular input does not make sense for your particular model, then MLJ can
-still handle this; you just need to define a non-tabular
-`input_scitype` trait. However, you should probably open an issue to
-clarify the appropriate declaration. The discussion below assumes
-input data is tabular.
-
-### Overview
-
-Writing an interface is fairly straightforward: just create a file or a module in your package including
-
-* a `using MLJBase` or `import MLJBase` statement
-* MLJ-compatible model types and constructors,
-* implementation of the `fit`, `predict`/`transform` and optionally `fitted_params` for your models,
-* metadata for your package and for each of your models
-
-We give some details for each step below with, each time, a few examples that you can mimic.
-The instructions are intentionally brief; refer to the [full documentation](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Adding-Models-for-General-Use-1) for additional details.
-
-### Model type and constructor
-
-MLJ-compatible constructors for your models need to meet the following requirements:
-
-* be `mutable struct`,
-* be subtypes of `MLJBase.Probabilistic` or `MLJBase.Deterministic` or `MLJBase.Unsupervised`,
-* have fields corresponding exclusively to hyperparameters,
-* have a keyword constructor assigning default values to all
-  hyperparameters.
-
-It is recommended that you use the `@mlj_model` macro from `MLJBase` to
-declare a (non parametric) model type:
-
-```julia
-@mlj_model mutable struct YourModel <: MLJBase.Deterministic
-    a::Float64 = 0.5::(_ > 0)
-    b::String  = "svd"::(_ in ("svd","qr"))
-end
-```
-
-That macro specifies:
-
-* A keyword constructor (here `YourModel(; a=..., b=...)`),
-* Default values for the hyperparameters,
-* Constraints on the hyperparameters where `_` refers to a value passed.
-
-Further to the last point, `a::Float64 = 0.5::(_ > 0)` indicates that the field `a` is a `Float64`, takes `0.5` as default value, and expects its value to be positive.
-
-If you decide **not** to use the `@mlj_model` macro (e.g. in the case of a parametric type), you will need to write a keyword constructor and a `clean!` method:
-
-```julia
-mutable struct YourModel <: MLJBase.Deterministic
-    a::Float64
-end
-function YourModel(; a=0.5)
-    model   = YourModel(a)
-    message = MLJBase.clean!(model)
-    isempty(message) || @warn message
-    return model
-end
-function clean!(m::YourModel)
-    warning = ""
-    if m.a <= 0
-        warning *= "Parameter `a` expected to be positive, resetting to 0.5"
-        m.a = 0.5
-    end
-    return warning
-end
-```
-
-**Additional notes**:
-
-- Please type all your fields if possible,
-- Please prefer `Symbol` over `String` if you can (e.g. to pass the name of a solver),
-- Please add constraints to your fields even if they seem obvious to you,,
-- Your model may have 0 fields, that's fine.
-
-**Examples**:
-
-- [KNNClassifier](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/NearestNeighbors.jl#L62-L69) which uses `@mlj_model`,
-- [XGBoostRegressor](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/XGBoost.jl#L17-L161) which does not.
-
-### Fit
-
-The implementation of `fit` will look like
-
-```julia
-function MLJBase.fit(m::YourModel, verbosity::Int, X, y, w=nothing)
-    # body ...
-    return (fitresult, cache, report)
-end
-```
-
-where `y` should only be there for a supervised model and `w` for a supervised model that supports sample weights.
-You **must** type `verbosity` to `Int` and you **must not** type `X`, `y` and `w` (MLJ handles that).
-
-#### Regressor
-
-In the body of the `fit` function, you should assume that `X` is a table and that `y` is an `AbstractVector` (for multitask regression it may be a table).
-
-Typical steps in the body of the `fit` function will be:
-
-* forming a matrix-view of the data, possibly transposed if your model expects a `p x n` formalism (MLJ assumes columns are features by default i.e. `n x p`), use `MLJBase.matrix` for this,
-* passing the data to your model,
-* returning the results as a tuple `(fitresult, cache, report)`.
-
-The `fitresult` part should contain everything that is needed at the
-`predict` or `transform` step, it should not be expected to be
-accessed by users.  The `cache` should be left to `nothing` for now.
-The `report` should be a `NamedTuple` with any auxiliary useful
-information that a user would want to know about the fit (e.g.,
-feature rankings). See more on this below.
-
-**Example**: GLM's [LinearRegressor](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L95-L105)
-
-
-#### Classifier
-
-For a classifier, the steps are fairly similar to a regressor with two particularities:
-
-1. `y` will be a categorical vector and you will typically want to use the integer encoding of `y` instead of the raw labels; use `MLJBase.int` for this,
-1.  You will need to pass the full pool of target labels (not just
-   those observed in the training data) and additionally, in the
-   `Deterministic` case, the encoding, to make these available to
-   `predict`. A simple way to do this is to pass `y[1]` in the
-   `fitresult`, for then `MLJBase.classes(y[1])` is a complete list of
-   possible categorical elements, and `d = MLJBase.decoder(y[1])` is a
-   method for recovering categorical elements from their integer
-   representations (e.g., `d(2)` is the categorical element with `2`
-   as encoding).
-
-**Examples**:
-
--  GLM's [BinaryClassifier](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L119-L131) (`Probabilistic`)
-
-- LIBSVM's [SVC](https://github.com/alan-turing-institute/MLJModels.jl/blob/master/src/LIBSVM.jl) (`Deterministic`)
-
-
-#### Transformer
-
-Nothing special for a transformer.
-
-**Example**: our [FillImputer](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/builtins/Transformers.jl#L54-L64)
-
-### Fitted parameters
-
-There is a function you can optionally implement which will return the
-learned parameters of your model for purposes of user-inspection. For
-instance, in the case of a linear regression, the user may want to get
-direct access to the coefficients and intercept. This should be as human and
-machine readable as practical (not a graphical representation) and the
-information should be combined in the form of a named tuple.
-
-The function will always look like:
-
-```julia
-function MLJBase.fitted_params(model::YourModel, fitresult)
-    # extract what's relevant from `fitresult`
-    # ...
-    # then return as a NamedTuple
-    return (learned_param1 = ..., learned_param2 = ...)
-end
-```
-
-**Example**: for [GLM models](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L133-L137)
-
-
-### Summary of user interface points (or, What to put where?)
-
-Recall that the `fitresult` returned as part of `fit` represents
-everything needed by `predict` (or `transform`) to make new
-predictions. It is not intended to be directly inspected by the
-user. Here is a summary of the interface points for users that your
-implementation creates:
-
-- Use `fitted_params` to expose *learned parameters*, such as linear
-  coefficients, to the user in a machine and human readable form (for
-  re-use in another model, for example).
-- Use the fields of your model struct for *hyperparameters*, i.e.,
-  those parameters declared by the user ahead of time that generally
-  affect the outcome of training. It is okay to add "control"
-  parameters (such a specifying an `acceleration` parameter specifying
-  computational resources, as
-  [here](https://github.com/alan-turing-institute/MLJ.jl/blob/master/src/ensembles.jl#L193)).
-- Use `report` to return *everything else*, including model-specific
-  *methods* (or other callable objects). This includes: feature rankings,
-  decision boundaries, SVM support vectors, clustering centres,
-  methods for visualizing training outcomes, methods for saving
-  learned parameters in a custom format, degrees of freedom, deviance,
-  etc. If there is a performance cost to extra functionality you want
-  to expose, the functionality can be toggled on/off through a
-  hyperparameter, but this should otherwise be avoided. For, example,
-  in a decision tree model `report.print_tree(depth)` might generate
-  a pretty tree representation of the learned tree, up to the
-  specified `depth`.
-
-### Predict/Transform
-
-The implementation of `predict` (for a supervised model) or
-`transform` (for an unsupervised one) will look like:
-
-```julia
-function MLJBase.predict(m::YourModel, fitresult, Xnew)
-    # ...
-end
-```
-
-Where `Xnew` should be expected to be a table and part of the logic in `predict` or `transform` may be similar to that in `fit`.
-
-The values returned should be:
-
-* (**Deterministic**): a vector of values (or Table if multi-target)
-* (**Probabilistic**): a vector of `Distribution` objects, for classifiers in particular, a vector of `UnivariateFinite`
-* (**Transformer**): a table
-
-In the case of a `Probabilistic` model, you may further want to
-implement a `predict_mean` or a `predict_mode`. However,
-MLJBase provides fallbacks, defined in terms of `predict`, whose performance may suffice.
-
-
-**Examples**
-
-- Deterministic regression: [KNNRegressor](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/NearestNeighbors.jl#L124-L145)
-- Probabilistic regression: [LinearRegressor](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L154-L158) and the [`predict_mean`](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L144-L147)
-- Probabilistic classification: [LogisticClassifier](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L165-L168)
-
-### Metadata
-
-Adding metadata for your model(s) is crucial for the discoverability of your package and its models and to make sure your model is used with data it can handle.
-You should use the `metadata_model` and `metadata_pkg` functionalities from `MLJBase` to do this:
-
-```julia
-const ALL_MODELS = Union{YourModel1, YourModel2, ...}
-
-metadata_pkg.(ALL_MODELS
-    name = "YourPackage",
-    uuid = "6ee0df7b-...", # see your Project.toml
-    url  = "https://...",  # URL to your package repo
-    julia = true,          # is it written entirely in Julia?
-    license = "MIT",       # your package license
-    is_wrapper = false,    # does it wrap around some other package?
-)
-
-# Then for each model,
-metadata_model(YourModel1,
-    input   = Table(Continuous),  # what input data is supported?
-    target  = AbstractVector{Continuous}, # for a supervised model, what target?
-    output  = Table(Continuous),  # for an unsupervised, what output?
-    weights = false,                              # does the model support sample weights?
-    descr   = "A short description of your model"
-	path    = "YourPackage.ModuleContainingModelStructDefinition.YourModel1"
-    )
-```
-
-**Examples**:
-
-- package metadata
-  - [GLM](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L179-L186)
-  - [MLJLinearModels](https://github.com/alan-turing-institute/MLJLinearModels.jl/blob/289a373a8357c4afc191711d0218aa1523e97f70/src/mlj/interface.jl#L91-L97)
-- model metadata
-  - [LinearRegressor](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/GLM.jl#L188-L193)
-  - [DecisionTree](https://github.com/alan-turing-institute/MLJModels.jl/blob/3687491b132be8493b6f7a322aedf66008caaab1/src/DecisionTree.jl#L225-L229)
-  - [A series of regressors](https://github.com/alan-turing-institute/MLJLinearModels.jl/blob/289a373a8357c4afc191711d0218aa1523e97f70/src/mlj/interface.jl#L105-L111)
-
----
-
-## Register a model to the model registry
-
-This is the final step, once you have a working interface with MLJ in your package.
-
-1. fork this repository and clone it locally, then, in your REPL,
-1. cd to `MLJModels/src/registry` and activate that environment,
-1. add `YourPackage` to the environment,
-1. cd back to `MLJModels` and activate that environment,
-1. run `using MLJModels; @update`.
-
-The last step updates
-
-- `MLJModels/src/registry/Metadata.toml` and
-- `MLJModels/src/registry/Models.toml`
-
-#### Does it work?
-
-1. in the activated environment from before, add `MLJ` and `YourPackage`,
-1. run `using MLJModels; @load YourModel pkg=YourPackage`
-
-Assuming that worked, commit and push your changes then open a PR on MLJModels' **`dev`** branch.
-
-MLJ maintainers will merge your PR once they've had a chance at making sure your interface works and your model(s) are appropriately tested.
-[
+Recall that an interface is loaded from within MLJ, together with the
+package providing the underlying algorithm, using the syntax `@load
+RidgeRegressor pkg=GLM`, with the `pkg` only necessary in ambiguous
+cases.
+
+
+## What's provided here?
+
+MLJModels contains:
+
+- interfaces, under [/src/](/src/), for "essential" Julia machine
+  learning packages which do not yet provide, or are unlikely to
+  provide, native MLJ model interfaces. The bulk of these are
+  [ScikitLearn.jl](https://github.com/cstjean/ScikitLearn.jl) models.
+  
+- a few models that are pre-loaded into MLJ, located at
+  [/src/builtins](/src/builtins), such as `OneHotEncoder`
+  and `ConstantClassifier`. 
+
+- the MLJ [model registry](src/registry/Metadata.toml), listing all
+  models that can be called from MLJ using `@load`. Package developers
+  can register new models by implementing the MLJ interface in their
+  package and following [these
+  instructions](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/).
+  
+
+## Instructions for updating the MLJ model registry
+
+Generally model registration is performed by administrators. If you
+have an interface you would like registered, open an issue on this repo. 
+
+To register all the models in GreatNewPackage with MLJ:
+
+- In a clone of the dev branch of
+  [MLJModels](https://github.com/alan-turing-institute/MLJModels.jl),
+  change to the `/src/registry/` directory and, in Julia, activate the
+  environment specified by the Project.toml there, after checking the
+  [compat] conditions there are up to date.
+  
+- Add `GreatNewPackage` to the environment.
+
+- In some environment in which your MLJModels clone has been added
+  using `Pkg.dev`, execute `using MLJModels; @update`. This updates
+  `src/registry/Metadata.toml` and `src/registry/Models.toml` (the
+  latter is generated for convenience and not used by MLJ).
+  
+- Test that interfaces load with `MLJModels.check_registry()`
+
+-  Quit your REPL session, whose namespace is now polluted.
+
+- Push your changes to an appropriate branch of MLJModels to make
+  the updated metadata available to users of the next MLJModels tagged
+  release.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ interfaces, and home of the MLJ model registry.
 ### Contents
 
  - [Who is this repo for?](#who-is-this-repo-for)
- - [What's provided here?](#what-is-provided-here)
+ - [What is provided here?](#what-is-provided-here)
  - [Instructions for updating the MLJ model registry](#instructions-for-updating-the-mlj-model-registry)
 
 ## Who is this repo for?
@@ -37,11 +37,11 @@ To list *all* model interfaces currently registered, do `using MLJ` or `using ML
 
 Recall that an interface is loaded from within MLJ, together with the
 package providing the underlying algorithm, using the syntax `@load
-RidgeRegressor pkg=GLM`, with the `pkg` only necessary in ambiguous
-cases.
+RidgeRegressor pkg=GLM`, where the `pkg` keyword is only necessary in
+ambiguous cases.
 
 
-## What's provided here?
+## What is provided here?
 
 MLJModels contains:
 
@@ -68,9 +68,8 @@ have an interface you would like registered, open an issue on this repo.
 
 To register all the models in GreatNewPackage with MLJ:
 
-- In a clone of the dev branch of
-  [MLJModels](https://github.com/alan-turing-institute/MLJModels.jl),
-  change to the `/src/registry/` directory and, in Julia, activate the
+- In the dev branch of a clone of the dev branch of MLJModels, change
+  to the `/src/registry/` directory and, in Julia, activate the
   environment specified by the Project.toml there, after checking the
   [compat] conditions there are up to date.
   

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Repository of selected
 [MLJ](https://github.com/alan-turing-institute/MLJ.jl) model
 interfaces, and home of the MLJ model registry.
 
+For instructions on integrating a new model with MLJ visit
+[here](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/)
+
+
 ### Contents
 
  - [Who is this repo for?](#who-is-this-repo-for)
@@ -64,25 +68,30 @@ MLJModels contains:
 ## Instructions for updating the MLJ model registry
 
 Generally model registration is performed by administrators. If you
-have an interface you would like registered, open an issue on this repo. 
+have an interface you would like registered, open an issue
+[here](https://github.com/alan-turing-institute/MLJ.jl/issues).
 
 To register all the models in GreatNewPackage with MLJ:
 
 - In the dev branch of a clone of the dev branch of MLJModels, change
   to the `/src/registry/` directory and, in Julia, activate the
   environment specified by the Project.toml there, after checking the
-  [compat] conditions there are up to date.
+  [compat] conditions there are up to date. **Do not use** `Revise`.
   
 - Add `GreatNewPackage` to the environment.
 
-- In some environment in which your MLJModels clone has been added
-  using `Pkg.dev`, execute `using MLJModels; @update`. This updates
+- In some environment to which your MLJModels clone has been added
+  (using `Pkg.dev`) execute `using MLJModels; @update`. This updates
   `src/registry/Metadata.toml` and `src/registry/Models.toml` (the
   latter is generated for convenience and not used by MLJ).
   
 - Test that interfaces load with `MLJModels.check_registry()`
 
--  Quit your REPL session, whose namespace is now polluted.
+- Quit your REPL session, whose namespace is now polluted.
+
+- *Note.* that your local MLJModels will not immediately adopt the
+  updated registry because that requires pre-compilation; for
+  technical reasons the registry is not loaded in `__init__`()`.
 
 - Push your changes to an appropriate branch of MLJModels to make
   the updated metadata available to users of the next MLJModels tagged

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -185,7 +185,7 @@ List all models whose names are in the namespace of the specified
 module `modl`, or meeting the `conditions`, if specified. Here a
 *condition* is a `Bool`-valued function on models.
 
-See also [models](@ref)
+See also [`models`](@ref)
 
 """
 function localmodels(args...; modl=Main)

--- a/src/registry/Metadata.toml
+++ b/src/registry/Metadata.toml
@@ -1,7 +1,7 @@
 
 [NearestNeighbors.KNNClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s110,1} where _s110<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s93,1} where _s93<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "NearestNeighbors"
 ":package_license" = "MIT"
@@ -15,7 +15,7 @@
 ":name" = "KNNClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:K, :algorithm, :metric, :leafsize, :reorder, :weights)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Symbol\", \"Distances.Metric\", \"Int64\", \"Bool\", \"Symbol\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -36,7 +36,7 @@
 ":name" = "KNNRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:K, :algorithm, :metric, :leafsize, :reorder, :weights)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Symbol\", \"Distances.Metric\", \"Int64\", \"Bool\", \"Symbol\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -57,7 +57,7 @@
 ":name" = "QuantileRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:delta, :lambda, :gamma, :penalty, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Real\", \"Real\", \"Real\", \"Union{String, Symbol}\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -78,7 +78,7 @@
 ":name" = "LogisticClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:lambda, :gamma, :penalty, :fit_intercept, :penalize_intercept, :solver, :multi_class)`"
 ":hyperparameter_types" = "`(\"Real\", \"Real\", \"Union{String, Symbol}\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -99,7 +99,7 @@
 ":name" = "MultinomialClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:lambda, :gamma, :penalty, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Real\", \"Real\", \"Union{String, Symbol}\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -120,7 +120,7 @@
 ":name" = "LADRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:lambda, :gamma, :penalty, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Real\", \"Real\", \"Union{String, Symbol}\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -141,7 +141,7 @@
 ":name" = "RidgeRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:lambda, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Real\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing)`"
@@ -162,7 +162,7 @@
 ":name" = "RobustRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:rho, :lambda, :gamma, :penalty, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"MLJLinearModels.RobustRho\", \"Real\", \"Real\", \"Union{String, Symbol}\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -183,7 +183,7 @@
 ":name" = "ElasticNetRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:lambda, :gamma, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Real\", \"Real\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing)`"
@@ -204,7 +204,7 @@
 ":name" = "LinearRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:fit_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing)`"
@@ -225,7 +225,7 @@
 ":name" = "LassoRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:lambda, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Real\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing)`"
@@ -246,14 +246,14 @@
 ":name" = "HuberRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:delta, :lambda, :gamma, :penalty, :fit_intercept, :penalize_intercept, :solver)`"
 ":hyperparameter_types" = "`(\"Real\", \"Real\", \"Real\", \"Union{String, Symbol}\", \"Bool\", \"Bool\", \"Union{Nothing, MLJLinearModels.Solver}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.ProbabilisticSGDClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s581,1} where _s581<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s566,1} where _s566<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -267,14 +267,14 @@
 ":name" = "ProbabilisticSGDClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:loss, :penalty, :alpha, :l1_ratio, :fit_intercept, :max_iter, :tol, :shuffle, :verbose, :epsilon, :n_jobs, :random_state, :learning_rate, :eta0, :power_t, :early_stopping, :validation_fraction, :n_iter_no_change, :class_weight, :warm_start, :average)`"
 ":hyperparameter_types" = "`(\"String\", \"String\", \"Float64\", \"Float64\", \"Bool\", \"Int64\", \"Union{Nothing, Float64}\", \"Bool\", \"Int64\", \"Float64\", \"Union{Nothing, Int64}\", \"Any\", \"String\", \"Float64\", \"Float64\", \"Bool\", \"Float64\", \"Int64\", \"Any\", \"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.RidgeCVClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s445,1} where _s445<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s430,1} where _s430<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -288,14 +288,14 @@
 ":name" = "RidgeCVClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alphas, :fit_intercept, :normalize, :scoring, :cv, :class_weight, :store_cv_values)`"
 ":hyperparameter_types" = "`(\"AbstractArray{Float64,N} where N\", \"Bool\", \"Bool\", \"Any\", \"Int64\", \"Any\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.LogisticClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s445,1} where _s445<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s430,1} where _s430<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -309,14 +309,14 @@
 ":name" = "LogisticClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:penalty, :dual, :tol, :C, :fit_intercept, :intercept_scaling, :class_weight, :random_state, :solver, :max_iter, :multi_class, :verbose, :warm_start, :n_jobs, :l1_ratio)`"
 ":hyperparameter_types" = "`(\"String\", \"Bool\", \"Float64\", \"Float64\", \"Bool\", \"Float64\", \"Any\", \"Any\", \"String\", \"Int64\", \"String\", \"Int64\", \"Bool\", \"Union{Nothing, Int64}\", \"Union{Nothing, Float64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.RandomForestRegressor]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:Union{AbstractArray{_s25,1} where _s25<:ScientificTypes.Count, AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous}`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -330,7 +330,7 @@
 ":name" = "RandomForestRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_estimators, :criterion, :max_depth, :min_samples_split, :min_samples_leaf, :min_weight_fraction_leaf, :max_features, :max_leaf_nodes, :min_impurity_decrease, :bootstrap, :oob_score, :n_jobs, :random_state, :verbose, :warm_start)`"
 ":hyperparameter_types" = "`(\"Int64\", \"String\", \"Union{Nothing, Int64}\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Float64\", \"Union{Nothing, Float64, Int64, String}\", \"Union{Nothing, Int64}\", \"Float64\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Any\", \"Int64\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -351,14 +351,14 @@
 ":name" = "ElasticNetCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:l1_ratio, :eps, :n_alphas, :alphas, :fit_intercept, :normalize, :precompute, :max_iter, :tol, :cv, :copy_X, :verbose, :n_jobs, :positive, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Union{Float64, Array{Float64,1}}\", \"Float64\", \"Int64\", \"Any\", \"Bool\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\", \"Int64\", \"Float64\", \"Any\", \"Bool\", \"Union{Bool, Int64}\", \"Union{Nothing, Int64}\", \"Bool\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.PerceptronClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s445,1} where _s445<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s430,1} where _s430<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -372,7 +372,7 @@
 ":name" = "PerceptronClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:penalty, :alpha, :fit_intercept, :max_iter, :tol, :shuffle, :verbose, :eta0, :n_jobs, :random_state, :early_stopping, :validation_fraction, :n_iter_no_change, :class_weight, :warm_start)`"
 ":hyperparameter_types" = "`(\"Union{Nothing, String}\", \"Float64\", \"Bool\", \"Int64\", \"Union{Nothing, Float64}\", \"Bool\", \"Int64\", \"Float64\", \"Union{Nothing, Int64}\", \"Any\", \"Bool\", \"Float64\", \"Int64\", \"Any\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -393,7 +393,7 @@
 ":name" = "MultiTaskLassoRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :fit_intercept, :normalize, :max_iter, :tol, :copy_X, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Bool\", \"Int64\", \"Float64\", \"Bool\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -414,7 +414,7 @@
 ":name" = "LinearRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:fit_intercept, :normalize, :copy_X, :n_jobs)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing)`"
@@ -454,7 +454,7 @@
 ":name" = "RidgeRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :fit_intercept, :normalize, :copy_X, :max_iter, :tol, :solver, :random_state)`"
 ":hyperparameter_types" = "`(\"Union{Float64, Array{Float64,1}}\", \"Bool\", \"Bool\", \"Bool\", \"Int64\", \"Float64\", \"String\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -475,7 +475,7 @@
 ":name" = "LassoLarsICRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:criterion, :fit_intercept, :verbose, :normalize, :precompute, :max_iter, :eps, :copy_X, :positive)`"
 ":hyperparameter_types" = "`(\"String\", \"Bool\", \"Union{Bool, Int64}\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\", \"Int64\", \"Float64\", \"Bool\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -496,7 +496,7 @@
 ":name" = "ARDRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_iter, :tol, :alpha_1, :alpha_2, :lambda_1, :lambda_2, :compute_score, :threshold_lambda, :fit_intercept, :normalize, :copy_X, :verbose)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Bool\", \"Float64\", \"Bool\", \"Bool\", \"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -517,14 +517,14 @@
 ":name" = "SVMNuRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:nu, :C, :kernel, :degree, :gamma, :coef0, :shrinking, :tol, :cache_size, :max_iter)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Float64\", \"Union{Function, String}\", \"Int64\", \"Union{Float64, String}\", \"Float64\", \"Bool\", \"Float64\", \"Float64\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.RidgeClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s445,1} where _s445<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s430,1} where _s430<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -538,7 +538,7 @@
 ":name" = "RidgeClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :fit_intercept, :normalize, :copy_X, :max_iter, :tol, :class_weight, :solver, :random_state)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Float64\", \"Any\", \"String\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -559,14 +559,14 @@
 ":name" = "SGDRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:loss, :penalty, :alpha, :l1_ratio, :fit_intercept, :max_iter, :tol, :shuffle, :verbose, :epsilon, :random_state, :learning_rate, :eta0, :power_t, :early_stopping, :validation_fraction, :n_iter_no_change, :warm_start, :average)`"
 ":hyperparameter_types" = "`(\"String\", \"String\", \"Float64\", \"Float64\", \"Bool\", \"Int64\", \"Float64\", \"Bool\", \"Union{Bool, Int64}\", \"Float64\", \"Any\", \"String\", \"Float64\", \"Float64\", \"Bool\", \"Float64\", \"Int64\", \"Bool\", \"Union{Bool, Int64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.ComplementNBClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Count)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -580,7 +580,7 @@
 ":name" = "ComplementNBClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :fit_prior, :class_prior, :norm)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Union{Nothing, AbstractArray{T,1} where T}\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing)`"
@@ -601,14 +601,14 @@
 ":name" = "HuberRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:epsilon, :max_iter, :alpha, :warm_start, :fit_intercept, :tol)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Int64\", \"Float64\", \"Bool\", \"Bool\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.SVMNuClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s109,1} where _s109<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s92,1} where _s92<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "unknown"
@@ -622,14 +622,14 @@
 ":name" = "SVMNuClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:nu, :kernel, :degree, :gamma, :coef0, :shrinking, :tol, :cache_size, :max_iter, :decision_function_shape, :random_state)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Union{Function, String}\", \"Int64\", \"Union{Float64, String}\", \"Float64\", \"Bool\", \"Float64\", \"Float64\", \"Int64\", \"String\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.GradientBoostingClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -643,7 +643,7 @@
 ":name" = "GradientBoostingClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:loss, :learning_rate, :n_estimators, :subsample, :criterion, :min_samples_split, :min_samples_leaf, :min_weight_fraction_leaf, :max_depth, :min_impurity_decrease, :init, :random_state, :max_features, :verbose, :max_leaf_nodes, :warm_start, :presort, :validation_fraction, :n_iter_no_change, :tol)`"
 ":hyperparameter_types" = "`(\"String\", \"Float64\", \"Int64\", \"Float64\", \"String\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Float64\", \"Int64\", \"Float64\", \"Any\", \"Any\", \"Union{Nothing, Float64, Int64, String}\", \"Int64\", \"Union{Nothing, Int64}\", \"Bool\", \"Union{Bool, String}\", \"Float64\", \"Union{Nothing, Int64}\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -664,7 +664,7 @@
 ":name" = "GaussianProcessRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:kernel, :alpha, :optimizer, :n_restarts_optimizer, :normalize_y, :copy_X_train, :random_state)`"
 ":hyperparameter_types" = "`(\"Any\", \"Union{Float64, AbstractArray}\", \"Any\", \"Int64\", \"Bool\", \"Bool\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -685,7 +685,7 @@
 ":name" = "LarsRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:fit_intercept, :verbose, :normalize, :precompute, :n_nonzero_coefs, :eps, :copy_X, :fit_path)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Union{Bool, Int64}\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\", \"Int64\", \"Float64\", \"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -704,14 +704,14 @@
 ":docstring" = "Mean shift clustering using a flat kernel. Mean shift clustering aims to discover \"blobs\" in a smooth density of samples. It is a centroid-based algorithm, which works by updating candidates for centroids to be the mean of the points within a given region. These candidates are then filtered in a post-processing stage to eliminate near-duplicates to form the final set of centroids.\n→ based on [ScikitLearn](https://github.com/cstjean/ScikitLearn.jl).\n→ do `@load MeanShift pkg=\"ScikitLearn\"` to use the model.\n→ do `?MeanShift` for documentation."
 ":name" = "MeanShift"
 ":is_supervised" = "`false`"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:bandwidth, :seeds, :bin_seeding, :min_bin_freq, :cluster_all, :n_jobs)`"
 ":hyperparameter_types" = "`(\"Union{Nothing, Float64}\", \"Union{Nothing, AbstractArray}\", \"Bool\", \"Int64\", \"Bool\", \"Union{Nothing, Int64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.SVMLClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s109,1} where _s109<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s92,1} where _s92<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "unknown"
@@ -725,7 +725,7 @@
 ":name" = "SVMLClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:C, :loss, :dual, :penalty, :tol, :max_iter, :intercept_scaling, :random_state)`"
 ":hyperparameter_types" = "`(\"Float64\", \"String\", \"Bool\", \"String\", \"Float64\", \"Int64\", \"Float64\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -746,7 +746,7 @@
 ":name" = "AdaBoostRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:base_estimator, :n_estimators, :learning_rate, :loss, :random_state)`"
 ":hyperparameter_types" = "`(\"Any\", \"Int64\", \"Float64\", \"String\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing)`"
@@ -765,7 +765,7 @@
 ":docstring" = "Perform Affinity Propagation Clustering of data.\n→ based on [ScikitLearn](https://github.com/cstjean/ScikitLearn.jl).\n→ do `@load AffinityPropagation pkg=\"ScikitLearn\"` to use the model.\n→ do `?AffinityPropagation` for documentation."
 ":name" = "AffinityPropagation"
 ":is_supervised" = "`false`"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:damping, :max_iter, :convergence_iter, :copy, :preference, :affinity, :verbose)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Int64\", \"Int64\", \"Bool\", \"Any\", \"String\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -786,7 +786,7 @@
 ":name" = "MultiTaskLassoCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:eps, :n_alphas, :alphas, :fit_intercept, :normalize, :max_iter, :tol, :copy_X, :cv, :verbose, :n_jobs, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Int64\", \"Any\", \"Bool\", \"Bool\", \"Int64\", \"Float64\", \"Bool\", \"Any\", \"Union{Bool, Int64}\", \"Union{Nothing, Int64}\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -807,7 +807,7 @@
 ":name" = "OrthogonalMatchingPursuitRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_nonzero_coefs, :tol, :fit_intercept, :normalize, :precompute)`"
 ":hyperparameter_types" = "`(\"Union{Nothing, Int64}\", \"Union{Nothing, Float64}\", \"Bool\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing)`"
@@ -828,14 +828,14 @@
 ":name" = "RidgeCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alphas, :fit_intercept, :normalize, :scoring, :cv, :gcv_mode, :store_cv_values)`"
 ":hyperparameter_types" = "`(\"Any\", \"Bool\", \"Bool\", \"Any\", \"Any\", \"Union{Nothing, String}\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.PassiveAggressiveClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s445,1} where _s445<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s430,1} where _s430<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -849,7 +849,7 @@
 ":name" = "PassiveAggressiveClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:C, :fit_intercept, :max_iter, :tol, :early_stopping, :validation_fraction, :n_iter_no_change, :shuffle, :verbose, :loss, :n_jobs, :random_state, :warm_start, :class_weight, :average)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Int64\", \"Float64\", \"Bool\", \"Float64\", \"Int64\", \"Bool\", \"Int64\", \"String\", \"Union{Nothing, Int64}\", \"Any\", \"Bool\", \"Any\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -870,14 +870,14 @@
 ":name" = "SVMRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:C, :kernel, :degree, :gamma, :coef0, :shrinking, :tol, :cache_size, :max_iter, :epsilon)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Union{Function, String}\", \"Int64\", \"Union{Float64, String}\", \"Float64\", \"Bool\", \"Float64\", \"Float64\", \"Int64\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.BernoulliNBClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Count)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -891,14 +891,14 @@
 ":name" = "BernoulliNBClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :binarize, :fit_prior, :class_prior)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Union{Nothing, Float64}\", \"Bool\", \"Union{Nothing, AbstractArray{T,1} where T}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.GaussianNBClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -912,14 +912,14 @@
 ":name" = "GaussianNBClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:priors, :var_smoothing)`"
 ":hyperparameter_types" = "`(\"Union{Nothing, AbstractArray{Float64,1}}\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing)`"
 
 [ScikitLearn.ExtraTreesClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -933,7 +933,7 @@
 ":name" = "ExtraTreesClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_estimators, :criterion, :max_depth, :min_samples_split, :min_samples_leaf, :min_weight_fraction_leaf, :max_features, :max_leaf_nodes, :min_impurity_decrease, :bootstrap, :oob_score, :n_jobs, :random_state, :verbose, :warm_start, :class_weight)`"
 ":hyperparameter_types" = "`(\"Int64\", \"String\", \"Union{Nothing, Int64}\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Float64\", \"Union{Nothing, Float64, Int64, String}\", \"Union{Nothing, Int64}\", \"Float64\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Any\", \"Int64\", \"Bool\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -952,7 +952,7 @@
 ":docstring" = "K-Means algorithm: find K centroids corresponding to K clusters in the data.\n→ based on [ScikitLearn](https://github.com/cstjean/ScikitLearn.jl).\n→ do `@load KMeans pkg=\"ScikitLearn\"` to use the model.\n→ do `?KMeans` for documentation."
 ":name" = "KMeans"
 ":is_supervised" = "`false`"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:n_clusters, :n_init, :max_iter, :tol, :verbose, :random_state, :copy_x, :n_jobs, :algorithm, :precompute_distances, :init)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Int64\", \"Int64\", \"Float64\", \"Int64\", \"Any\", \"Bool\", \"Union{Nothing, Int64}\", \"String\", \"Union{Bool, String}\", \"Union{String, AbstractArray}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -973,7 +973,7 @@
 ":name" = "MultiTaskElasticNetCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:l1_ratio, :eps, :n_alphas, :alphas, :fit_intercept, :normalize, :max_iter, :tol, :cv, :copy_X, :verbose, :n_jobs, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Union{Float64, Array{Float64,1}}\", \"Float64\", \"Int64\", \"Any\", \"Bool\", \"Bool\", \"Int64\", \"Float64\", \"Any\", \"Bool\", \"Union{Bool, Int64}\", \"Union{Nothing, Int64}\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -994,7 +994,7 @@
 ":name" = "LassoLarsCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:fit_intercept, :verbose, :max_iter, :normalize, :precompute, :cv, :max_n_alphas, :n_jobs, :eps, :copy_X, :positive)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Union{Bool, Int64}\", \"Int64\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\", \"Any\", \"Int64\", \"Union{Nothing, Int64}\", \"Float64\", \"Bool\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1015,14 +1015,14 @@
 ":name" = "OrthogonalMatchingPursuitCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:copy, :fit_intercept, :normalize, :max_iter, :cv, :n_jobs, :verbose)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Any\", \"Union{Nothing, Int64}\", \"Union{Bool, Int64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.AdaBoostClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s581,1} where _s581<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s566,1} where _s566<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1036,7 +1036,7 @@
 ":name" = "AdaBoostClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:base_estimator, :n_estimators, :learning_rate, :algorithm, :random_state)`"
 ":hyperparameter_types" = "`(\"Any\", \"Int64\", \"Float64\", \"String\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing)`"
@@ -1057,7 +1057,7 @@
 ":name" = "PassiveAggressiveRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:C, :fit_intercept, :max_iter, :tol, :early_stopping, :validation_fraction, :n_iter_no_change, :shuffle, :verbose, :loss, :epsilon, :random_state, :warm_start, :average)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Int64\", \"Float64\", \"Bool\", \"Float64\", \"Int64\", \"Bool\", \"Union{Bool, Int64}\", \"String\", \"Float64\", \"Any\", \"Bool\", \"Union{Bool, Int64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1078,7 +1078,7 @@
 ":name" = "BayesianRidgeRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_iter, :tol, :alpha_1, :alpha_2, :lambda_1, :lambda_2, :compute_score, :fit_intercept, :normalize, :copy_X, :verbose)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Bool\", \"Bool\", \"Bool\", \"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1099,14 +1099,14 @@
 ":name" = "RANSACRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:base_estimator, :min_samples, :residual_threshold, :is_data_valid, :is_model_valid, :max_trials, :max_skips, :stop_n_inliers, :stop_score, :stop_probability, :loss, :random_state)`"
 ":hyperparameter_types" = "`(\"Any\", \"Union{Float64, Int64}\", \"Union{Nothing, Float64}\", \"Any\", \"Any\", \"Int64\", \"Int64\", \"Int64\", \"Float64\", \"Float64\", \"Union{Function, String}\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.BaggingClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s581,1} where _s581<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s566,1} where _s566<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1120,14 +1120,14 @@
 ":name" = "BaggingClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:base_estimator, :n_estimators, :max_samples, :max_features, :bootstrap, :bootstrap_features, :oob_score, :warm_start, :n_jobs, :random_state, :verbose)`"
 ":hyperparameter_types" = "`(\"Any\", \"Int64\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Bool\", \"Bool\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Any\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.GaussianProcessClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s581,1} where _s581<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s566,1} where _s566<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1141,7 +1141,7 @@
 ":name" = "GaussianProcessClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:kernel, :optimizer, :n_restarts_optimizer, :copy_X_train, :random_state, :max_iter_predict, :warm_start, :multi_class)`"
 ":hyperparameter_types" = "`(\"Any\", \"Any\", \"Int64\", \"Bool\", \"Any\", \"Int64\", \"Bool\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1181,7 +1181,7 @@
 ":name" = "KNeighborsRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_neighbors, :weights, :algorithm, :leaf_size, :p, :metric, :metric_params, :n_jobs)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Union{Function, String}\", \"String\", \"Int64\", \"Int64\", \"Any\", \"Any\", \"Union{Nothing, Int64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1200,7 +1200,7 @@
 ":docstring" = "Mini-Batch K-Means clustering.\n→ based on [ScikitLearn](https://github.com/cstjean/ScikitLearn.jl).\n→ do `@load MiniBatchKMeans pkg=\"ScikitLearn\"` to use the model.\n→ do `?MiniBatchKMeans` for documentation."
 ":name" = "MiniBatchKMeans"
 ":is_supervised" = "`false`"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:n_clusters, :max_iter, :batch_size, :verbose, :compute_labels, :random_state, :tol, :max_no_improvement, :init_size, :n_init, :init, :reassignment_ratio)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Int64\", \"Int64\", \"Int64\", \"Bool\", \"Any\", \"Float64\", \"Int64\", \"Union{Nothing, Int64}\", \"Int64\", \"Union{String, AbstractArray}\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1221,7 +1221,7 @@
 ":name" = "LassoCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:eps, :n_alphas, :alphas, :fit_intercept, :normalize, :precompute, :max_iter, :tol, :copy_X, :cv, :verbose, :n_jobs, :positive, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Int64\", \"Any\", \"Bool\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\", \"Int64\", \"Float64\", \"Bool\", \"Any\", \"Union{Bool, Int64}\", \"Union{Nothing, Int64}\", \"Bool\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1242,7 +1242,7 @@
 ":name" = "DummyRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:strategy, :constant, :quantile)`"
 ":hyperparameter_types" = "`(\"String\", \"Any\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing)`"
@@ -1263,7 +1263,7 @@
 ":name" = "LassoLarsRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :fit_intercept, :verbose, :normalize, :precompute, :max_iter, :eps, :copy_X, :fit_path, :positive)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Union{Bool, Int64}\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\", \"Int64\", \"Float64\", \"Bool\", \"Bool\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1284,14 +1284,14 @@
 ":name" = "LarsCVRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:fit_intercept, :verbose, :max_iter, :normalize, :precompute, :cv, :max_n_alphas, :n_jobs, :eps, :copy_X)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Union{Bool, Int64}\", \"Int64\", \"Bool\", \"Union{Bool, String, AbstractArray{T,2} where T}\", \"Any\", \"Int64\", \"Union{Nothing, Int64}\", \"Float64\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.KNeighborsClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1305,7 +1305,7 @@
 ":name" = "KNeighborsClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_neighbors, :weights, :algorithm, :leaf_size, :p, :metric, :metric_params, :n_jobs)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Union{Function, String}\", \"String\", \"Int64\", \"Int64\", \"Any\", \"Any\", \"Union{Nothing, Int64}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1331,7 +1331,7 @@
 
 [ScikitLearn.DummyClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1345,7 +1345,7 @@
 ":name" = "DummyClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:strategy, :constant, :random_state)`"
 ":hyperparameter_types" = "`(\"String\", \"Any\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing)`"
@@ -1366,14 +1366,14 @@
 ":name" = "BaggingRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:base_estimator, :n_estimators, :max_samples, :max_features, :bootstrap, :bootstrap_features, :oob_score, :warm_start, :n_jobs, :random_state, :verbose)`"
 ":hyperparameter_types" = "`(\"Any\", \"Int64\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Bool\", \"Bool\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Any\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.BayesianQDA]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1387,14 +1387,14 @@
 ":name" = "BayesianQDA"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:priors, :reg_param, :store_covariance, :tol)`"
 ":hyperparameter_types" = "`(\"Union{Nothing, AbstractArray{T,1} where T}\", \"Float64\", \"Bool\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.BayesianLDA]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1408,14 +1408,14 @@
 ":name" = "BayesianLDA"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:solver, :shrinkage, :priors, :n_components, :store_covariance, :tol)`"
 ":hyperparameter_types" = "`(\"String\", \"Union{Nothing, Float64, String}\", \"Union{Nothing, AbstractArray{T,1} where T}\", \"Union{Nothing, Int64}\", \"Bool\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.SGDClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s581,1} where _s581<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s566,1} where _s566<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1429,7 +1429,7 @@
 ":name" = "SGDClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:loss, :penalty, :alpha, :l1_ratio, :fit_intercept, :max_iter, :tol, :shuffle, :verbose, :epsilon, :n_jobs, :random_state, :learning_rate, :eta0, :power_t, :early_stopping, :validation_fraction, :n_iter_no_change, :class_weight, :warm_start, :average)`"
 ":hyperparameter_types" = "`(\"String\", \"String\", \"Float64\", \"Float64\", \"Bool\", \"Int64\", \"Union{Nothing, Float64}\", \"Bool\", \"Int64\", \"Float64\", \"Union{Nothing, Int64}\", \"Any\", \"String\", \"Float64\", \"Float64\", \"Bool\", \"Float64\", \"Int64\", \"Any\", \"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1450,7 +1450,7 @@
 ":name" = "TheilSenRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:fit_intercept, :copy_X, :max_subpopulation, :n_subsamples, :max_iter, :tol, :random_state, :n_jobs, :verbose)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Bool\", \"Int64\", \"Union{Nothing, Int64}\", \"Int64\", \"Float64\", \"Any\", \"Union{Nothing, Int64}\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1488,7 +1488,7 @@
 ":docstring" = "Memory-efficient, online-learning algorithm provided as an alternative to MiniBatchKMeans. Note: noisy samples are given the label -1.\n→ based on [ScikitLearn](https://github.com/cstjean/ScikitLearn.jl).\n→ do `@load Birch pkg=\"ScikitLearn\"` to use the model.\n→ do `?Birch` for documentation."
 ":name" = "Birch"
 ":is_supervised" = "`false`"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:threshold, :branching_factor, :n_clusters, :compute_labels, :copy)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Int64\", \"Int64\", \"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing)`"
@@ -1528,14 +1528,14 @@
 ":name" = "ElasticNetRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :l1_ratio, :fit_intercept, :normalize, :precompute, :max_iter, :copy_X, :tol, :warm_start, :positive, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Float64\", \"Bool\", \"Bool\", \"Union{Bool, AbstractArray{T,2} where T}\", \"Int64\", \"Bool\", \"Float64\", \"Bool\", \"Bool\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.RandomForestClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:Union{AbstractArray{_s25,1} where _s25<:ScientificTypes.Count, AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous}`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1549,14 +1549,14 @@
 ":name" = "RandomForestClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_estimators, :criterion, :max_depth, :min_samples_split, :min_samples_leaf, :min_weight_fraction_leaf, :max_features, :max_leaf_nodes, :min_impurity_decrease, :bootstrap, :oob_score, :n_jobs, :random_state, :verbose, :warm_start, :class_weight)`"
 ":hyperparameter_types" = "`(\"Int64\", \"String\", \"Union{Nothing, Int64}\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Float64\", \"Union{Nothing, Float64, Int64, String}\", \"Union{Nothing, Int64}\", \"Float64\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Any\", \"Int64\", \"Bool\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.LogisticCVClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s445,1} where _s445<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s430,1} where _s430<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1570,7 +1570,7 @@
 ":name" = "LogisticCVClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:Cs, :fit_intercept, :cv, :dual, :penalty, :scoring, :solver, :tol, :max_iter, :class_weight, :n_jobs, :verbose, :refit, :intercept_scaling, :multi_class, :random_state, :l1_ratios)`"
 ":hyperparameter_types" = "`(\"Union{Int64, AbstractArray{Float64,1}}\", \"Bool\", \"Any\", \"Bool\", \"String\", \"Any\", \"String\", \"Float64\", \"Int64\", \"Any\", \"Union{Nothing, Int64}\", \"Int64\", \"Bool\", \"Float64\", \"String\", \"Any\", \"Union{Nothing, AbstractArray{Float64,1}}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1591,7 +1591,7 @@
 ":name" = "MultiTaskElasticNetRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :l1_ratio, :fit_intercept, :normalize, :copy_X, :max_iter, :tol, :warm_start, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Union{Float64, Array{Float64,1}}\", \"Bool\", \"Bool\", \"Bool\", \"Int64\", \"Float64\", \"Bool\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1612,7 +1612,7 @@
 ":name" = "ExtraTreesRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_estimators, :criterion, :max_depth, :min_samples_split, :min_samples_leaf, :min_weight_fraction_leaf, :max_features, :max_leaf_nodes, :min_impurity_decrease, :bootstrap, :oob_score, :n_jobs, :random_state, :verbose, :warm_start)`"
 ":hyperparameter_types" = "`(\"Int64\", \"String\", \"Union{Nothing, Int64}\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Float64\", \"Union{Nothing, Float64, Int64, String}\", \"Union{Nothing, Int64}\", \"Float64\", \"Bool\", \"Bool\", \"Union{Nothing, Int64}\", \"Any\", \"Int64\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1633,14 +1633,14 @@
 ":name" = "LassoRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :fit_intercept, :normalize, :precompute, :copy_X, :max_iter, :tol, :warm_start, :positive, :random_state, :selection)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Bool\", \"Union{Bool, AbstractArray{T,2} where T}\", \"Bool\", \"Int64\", \"Float64\", \"Bool\", \"Bool\", \"Any\", \"String\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.MultinomialNBClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Count)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "BSD"
@@ -1654,7 +1654,7 @@
 ":name" = "MultinomialNBClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha, :fit_prior, :class_prior)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Bool\", \"Union{Nothing, AbstractArray{T,1} where T}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing)`"
@@ -1675,14 +1675,14 @@
 ":name" = "GradientBoostingRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:loss, :learning_rate, :n_estimators, :subsample, :criterion, :min_samples_split, :min_samples_leaf, :min_weight_fraction_leaf, :max_depth, :min_impurity_decrease, :init, :random_state, :max_features, :alpha, :verbose, :max_leaf_nodes, :warm_start, :presort, :validation_fraction, :n_iter_no_change, :tol)`"
 ":hyperparameter_types" = "`(\"String\", \"Float64\", \"Int64\", \"Float64\", \"String\", \"Union{Float64, Int64}\", \"Union{Float64, Int64}\", \"Float64\", \"Int64\", \"Float64\", \"Any\", \"Any\", \"Union{Nothing, Float64, Int64, String}\", \"Float64\", \"Int64\", \"Union{Nothing, Int64}\", \"Bool\", \"Union{Bool, String}\", \"Float64\", \"Union{Nothing, Int64}\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [ScikitLearn.SVMClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s109,1} where _s109<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s92,1} where _s92<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "ScikitLearn"
 ":package_license" = "unknown"
@@ -1696,7 +1696,7 @@
 ":name" = "SVMClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:C, :kernel, :degree, :gamma, :coef0, :shrinking, :tol, :cache_size, :max_iter, :decision_function_shape, :random_state)`"
 ":hyperparameter_types" = "`(\"Float64\", \"Union{Function, String}\", \"Int64\", \"Union{Float64, String}\", \"Float64\", \"Bool\", \"Float64\", \"Float64\", \"Int64\", \"String\", \"Any\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1717,14 +1717,14 @@
 ":name" = "SVMLRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:C, :loss, :fit_intercept, :dual, :tol, :max_iter, :epsilon)`"
 ":hyperparameter_types" = "`(\"Float64\", \"String\", \"Bool\", \"Bool\", \"Float64\", \"Int64\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [NaiveBayes.GaussianNBClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s670,1} where _s670<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s655,1} where _s655<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "NaiveBayes"
 ":package_license" = "unknown"
@@ -1738,14 +1738,14 @@
 ":name" = "GaussianNBClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "``"
 ":hyperparameter_types" = "``"
 ":hyperparameter_ranges" = "``"
 
 [NaiveBayes.MultinomialNBClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Count)`"
-":target_scitype" = "`AbstractArray{_s670,1} where _s670<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s655,1} where _s655<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "NaiveBayes"
 ":package_license" = "unknown"
@@ -1759,7 +1759,7 @@
 ":name" = "MultinomialNBClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:alpha,)`"
 ":hyperparameter_types" = "`(\"Int64\",)`"
 ":hyperparameter_ranges" = "`(nothing,)`"
@@ -1801,7 +1801,7 @@
 ":prediction_type" = ":unknown"
 ":implemented_methods" = [":clean!", ":evaluate", ":fit"]
 ":hyperparameters" = "`(:model, :resampling, :measure, :weights, :operation, :acceleration, :check_measure, :repeats)`"
-":hyperparameter_types" = "`(\"MLJModelInterface.Supervised\", \"Any\", \"Any\", \"Union{Nothing, AbstractArray{_s223,1} where _s223<:Real}\", \"Any\", \"ComputationalResources.AbstractResource\", \"Bool\", \"Int64\")`"
+":hyperparameter_types" = "`(\"MLJModelInterface.Supervised\", \"Any\", \"Any\", \"Union{Nothing, AbstractArray{_s234,1} where _s234<:Real}\", \"Any\", \"ComputationalResources.AbstractResource\", \"Bool\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [MultivariateStats.ICA]
@@ -1820,12 +1820,12 @@
 ":is_supervised" = "`false`"
 ":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:k, :alg, :fun, :do_whiten, :maxiter, :tol, :winit, :mean)`"
-":hyperparameter_types" = "`(\"Int64\", \"Symbol\", \"Symbol\", \"Bool\", \"Int64\", \"Real\", \"Union{Nothing, Array{_s671,2} where _s671<:Real}\", \"Union{Nothing, Array{Float64,1}, Real}\")`"
+":hyperparameter_types" = "`(\"Int64\", \"Symbol\", \"Symbol\", \"Bool\", \"Int64\", \"Real\", \"Union{Nothing, Array{_s656,2} where _s656<:Real}\", \"Union{Nothing, Array{Float64,1}, Real}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [MultivariateStats.BayesianLDA]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MultivariateStats"
 ":package_license" = "MIT"
@@ -1839,14 +1839,14 @@
 ":name" = "BayesianLDA"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:method, :cov_w, :cov_b, :out_dim, :regcoef, :priors)`"
 ":hyperparameter_types" = "`(\"Symbol\", \"StatsBase.CovarianceEstimator\", \"StatsBase.CovarianceEstimator\", \"Int64\", \"Float64\", \"Union{Nothing, MLJBase.UnivariateFinite}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [MultivariateStats.BayesianSubspaceLDA]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MultivariateStats"
 ":package_license" = "MIT"
@@ -1860,7 +1860,7 @@
 ":name" = "BayesianSubspaceLDA"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:normalize, :out_dim, :priors)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Int64\", \"Union{Nothing, MLJBase.UnivariateFinite}\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing)`"
@@ -1881,7 +1881,7 @@
 ":name" = "RidgeRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:lambda,)`"
 ":hyperparameter_types" = "`(\"Real\",)`"
 ":hyperparameter_ranges" = "`(nothing,)`"
@@ -1907,7 +1907,7 @@
 
 [MultivariateStats.LDA]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MultivariateStats"
 ":package_license" = "MIT"
@@ -1921,7 +1921,7 @@
 ":name" = "LDA"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:method, :cov_w, :cov_b, :out_dim, :regcoef, :dist)`"
 ":hyperparameter_types" = "`(\"Symbol\", \"StatsBase.CovarianceEstimator\", \"StatsBase.CovarianceEstimator\", \"Int64\", \"Float64\", \"Distances.SemiMetric\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -1947,7 +1947,7 @@
 
 [MultivariateStats.SubspaceLDA]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MultivariateStats"
 ":package_license" = "MIT"
@@ -1961,14 +1961,14 @@
 ":name" = "SubspaceLDA"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:normalize, :out_dim, :dist)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Int64\", \"Distances.SemiMetric\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing)`"
 
 [DecisionTree.AdaBoostStumpClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:Union{AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous, AbstractArray{_s25,1} where _s25<:ScientificTypes.Count, AbstractArray{_s25,1} where _s25<:ScientificTypes.OrderedFactor}`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "DecisionTree"
 ":package_license" = "MIT"
@@ -1982,7 +1982,7 @@
 ":name" = "AdaBoostStumpClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:n_iter, :pdf_smoothing)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing)`"
@@ -2003,14 +2003,14 @@
 ":name" = "DecisionTreeRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:max_depth, :min_samples_leaf, :min_samples_split, :min_purity_increase, :n_subfeatures, :post_prune, :merge_purity_threshold)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Int64\", \"Int64\", \"Float64\", \"Int64\", \"Bool\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [DecisionTree.DecisionTreeClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:Union{AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous, AbstractArray{_s25,1} where _s25<:ScientificTypes.Count, AbstractArray{_s25,1} where _s25<:ScientificTypes.OrderedFactor}`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "DecisionTree"
 ":package_license" = "MIT"
@@ -2024,7 +2024,7 @@
 ":name" = "DecisionTreeClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:max_depth, :min_samples_leaf, :min_samples_split, :min_purity_increase, :n_subfeatures, :post_prune, :merge_purity_threshold, :pdf_smoothing, :display_depth)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Int64\", \"Int64\", \"Float64\", \"Int64\", \"Bool\", \"Float64\", \"Float64\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -2045,14 +2045,14 @@
 ":name" = "RandomForestRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:max_depth, :min_samples_leaf, :min_samples_split, :min_purity_increase, :n_subfeatures, :n_trees, :sampling_fraction, :pdf_smoothing)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Int64\", \"Int64\", \"Float64\", \"Int64\", \"Int64\", \"Float64\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [DecisionTree.RandomForestClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:Union{AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous, AbstractArray{_s25,1} where _s25<:ScientificTypes.Count, AbstractArray{_s25,1} where _s25<:ScientificTypes.OrderedFactor}`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "DecisionTree"
 ":package_license" = "MIT"
@@ -2066,7 +2066,7 @@
 ":name" = "RandomForestClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params"]
 ":hyperparameters" = "`(:max_depth, :min_samples_leaf, :min_samples_split, :min_purity_increase, :n_subfeatures, :n_trees, :sampling_fraction, :pdf_smoothing)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Int64\", \"Int64\", \"Float64\", \"Int64\", \"Int64\", \"Float64\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -2085,7 +2085,7 @@
 ":docstring" = "K-Means algorithm: find K centroids corresponding to K clusters in the data.\n\n→ based on [Clustering](https://github.com/JuliaStats/Clustering.jl).\n→ do `@load KMeans pkg=\"Clustering\"` to use the model.\n→ do `?KMeans` for documentation."
 ":name" = "KMeans"
 ":is_supervised" = "`false`"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:k, :metric)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Distances.SemiMetric\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing)`"
@@ -2104,7 +2104,7 @@
 ":docstring" = "K-Medoids algorithm: find K centroids corresponding to K clusters in the data.\nUnlike K-Means, the centroids are found among data points themselves.\"\n\n→ based on [Clustering](https://github.com/JuliaStats/Clustering.jl).\n→ do `@load KMedoids pkg=\"Clustering\"` to use the model.\n→ do `?KMedoids` for documentation."
 ":name" = "KMedoids"
 ":is_supervised" = "`false`"
-":implemented_methods" = [":clean!", ":fit", ":fitted_params", ":predict", ":transform"]
+":implemented_methods" = [":predict", ":clean!", ":fit", ":fitted_params", ":transform"]
 ":hyperparameters" = "`(:k, :metric)`"
 ":hyperparameter_types" = "`(\"Int64\", \"Distances.SemiMetric\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing)`"
@@ -2125,7 +2125,7 @@
 ":name" = "XGBoostCount"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:num_round, :booster, :disable_default_eval_metric, :eta, :gamma, :max_depth, :min_child_weight, :max_delta_step, :subsample, :colsample_bytree, :colsample_bylevel, :lambda, :alpha, :tree_method, :sketch_eps, :scale_pos_weight, :updater, :refresh_leaf, :process_type, :grow_policy, :max_leaves, :max_bin, :predictor, :sample_type, :normalize_type, :rate_drop, :one_drop, :skip_drop, :feature_selector, :top_k, :tweedie_variance_power, :objective, :base_score, :eval_metric, :seed)`"
 ":hyperparameter_types" = "`(\"Int64\", \"String\", \"Int64\", \"Float64\", \"Float64\", \"Int64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"String\", \"Float64\", \"Float64\", \"String\", \"Union{Bool, Int64}\", \"String\", \"String\", \"Int64\", \"Int64\", \"String\", \"String\", \"String\", \"Float64\", \"Any\", \"Float64\", \"String\", \"Int64\", \"Float64\", \"Any\", \"Float64\", \"Any\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -2146,14 +2146,14 @@
 ":name" = "XGBoostRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:num_round, :booster, :disable_default_eval_metric, :eta, :gamma, :max_depth, :min_child_weight, :max_delta_step, :subsample, :colsample_bytree, :colsample_bylevel, :lambda, :alpha, :tree_method, :sketch_eps, :scale_pos_weight, :updater, :refresh_leaf, :process_type, :grow_policy, :max_leaves, :max_bin, :predictor, :sample_type, :normalize_type, :rate_drop, :one_drop, :skip_drop, :feature_selector, :top_k, :tweedie_variance_power, :objective, :base_score, :eval_metric, :seed)`"
 ":hyperparameter_types" = "`(\"Int64\", \"String\", \"Int64\", \"Float64\", \"Float64\", \"Int64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"String\", \"Float64\", \"Float64\", \"String\", \"Union{Bool, Int64}\", \"String\", \"String\", \"Int64\", \"Int64\", \"String\", \"String\", \"String\", \"Float64\", \"Any\", \"Float64\", \"String\", \"Int64\", \"Float64\", \"Any\", \"Float64\", \"Any\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [XGBoost.XGBoostClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "XGBoost"
 ":package_license" = "unknown"
@@ -2167,14 +2167,98 @@
 ":name" = "XGBoostClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":clean!", ":fit", ":predict"]
+":implemented_methods" = [":predict", ":clean!", ":fit"]
 ":hyperparameters" = "`(:num_round, :booster, :disable_default_eval_metric, :eta, :gamma, :max_depth, :min_child_weight, :max_delta_step, :subsample, :colsample_bytree, :colsample_bylevel, :lambda, :alpha, :tree_method, :sketch_eps, :scale_pos_weight, :updater, :refresh_leaf, :process_type, :grow_policy, :max_leaves, :max_bin, :predictor, :sample_type, :normalize_type, :rate_drop, :one_drop, :skip_drop, :feature_selector, :top_k, :tweedie_variance_power, :objective, :base_score, :eval_metric, :seed)`"
 ":hyperparameter_types" = "`(\"Int64\", \"String\", \"Int64\", \"Float64\", \"Float64\", \"Int64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"Float64\", \"String\", \"Float64\", \"Float64\", \"String\", \"Union{Bool, Int64}\", \"String\", \"String\", \"Int64\", \"Int64\", \"String\", \"String\", \"String\", \"Float64\", \"Any\", \"Float64\", \"String\", \"Int64\", \"Float64\", \"Any\", \"Float64\", \"Any\", \"Int64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
+[EvoTrees.EvoTreeClassifier]
+":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
+":target_scitype" = "`AbstractArray{_s25,1} where _s25<:ScientificTypes.Finite`"
+":is_pure_julia" = "`true`"
+":package_name" = "EvoTrees"
+":package_license" = "Apache"
+":load_path" = "EvoTrees.EvoTreeClassifier"
+":package_uuid" = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
+":package_url" = "https://github.com/Evovest/EvoTrees.jl"
+":is_wrapper" = "`false`"
+":supports_weights" = "`false`"
+":supports_online" = "`false`"
+":docstring" = "Multi-classification with softmax and cross-entropy loss.\n→ based on [EvoTrees](https://github.com/Evovest/EvoTrees.jl).\n→ do `@load EvoTreeClassifier pkg=\"EvoTrees\"` to use the model.\n→ do `?EvoTreeClassifier` for documentation."
+":name" = "EvoTreeClassifier"
+":is_supervised" = "`true`"
+":prediction_type" = ":probabilistic"
+":implemented_methods" = [":predict"]
+":hyperparameters" = "`(:loss, :nrounds, :λ, :γ, :η, :max_depth, :min_weight, :rowsample, :colsample, :nbins, :α, :metric, :seed)`"
+":hyperparameter_types" = "`(\"EvoTrees.ModelType\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"Symbol\", \"Int64\")`"
+":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
+
+[EvoTrees.EvoTreeGaussian]
+":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
+":target_scitype" = "`AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous`"
+":is_pure_julia" = "`true`"
+":package_name" = "EvoTrees"
+":package_license" = "Apache"
+":load_path" = "EvoTrees.EvoTreeGaussian"
+":package_uuid" = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
+":package_url" = "https://github.com/Evovest/EvoTrees.jl"
+":is_wrapper" = "`false`"
+":supports_weights" = "`false`"
+":supports_online" = "`false`"
+":docstring" = "Gaussian maximum likelihood of μ and σ².\n→ based on [EvoTrees](https://github.com/Evovest/EvoTrees.jl).\n→ do `@load EvoTreeGaussian pkg=\"EvoTrees\"` to use the model.\n→ do `?EvoTreeGaussian` for documentation."
+":name" = "EvoTreeGaussian"
+":is_supervised" = "`true`"
+":prediction_type" = ":probabilistic"
+":implemented_methods" = [":predict"]
+":hyperparameters" = "`(:loss, :nrounds, :λ, :γ, :η, :max_depth, :min_weight, :rowsample, :colsample, :nbins, :α, :metric, :seed)`"
+":hyperparameter_types" = "`(\"EvoTrees.ModelType\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"Symbol\", \"Int64\")`"
+":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
+
+[EvoTrees.EvoTreeRegressor]
+":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
+":target_scitype" = "`AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous`"
+":is_pure_julia" = "`true`"
+":package_name" = "EvoTrees"
+":package_license" = "Apache"
+":load_path" = "EvoTrees.EvoTreeRegressor"
+":package_uuid" = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
+":package_url" = "https://github.com/Evovest/EvoTrees.jl"
+":is_wrapper" = "`false`"
+":supports_weights" = "`false`"
+":supports_online" = "`false`"
+":docstring" = "Regression models with various underlying methods: least square, quantile, logistic.\n→ based on [EvoTrees](https://github.com/Evovest/EvoTrees.jl).\n→ do `@load EvoTreeRegressor pkg=\"EvoTrees\"` to use the model.\n→ do `?EvoTreeRegressor` for documentation."
+":name" = "EvoTreeRegressor"
+":is_supervised" = "`true`"
+":prediction_type" = ":deterministic"
+":implemented_methods" = [":predict"]
+":hyperparameters" = "`(:loss, :nrounds, :λ, :γ, :η, :max_depth, :min_weight, :rowsample, :colsample, :nbins, :α, :metric, :seed)`"
+":hyperparameter_types" = "`(\"EvoTrees.ModelType\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"Symbol\", \"Int64\")`"
+":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
+
+[EvoTrees.EvoTreeCount]
+":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
+":target_scitype" = "`AbstractArray{_s25,1} where _s25<:ScientificTypes.Count`"
+":is_pure_julia" = "`true`"
+":package_name" = "EvoTrees"
+":package_license" = "Apache"
+":load_path" = "EvoTrees.EvoTreeCount"
+":package_uuid" = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
+":package_url" = "https://github.com/Evovest/EvoTrees.jl"
+":is_wrapper" = "`false`"
+":supports_weights" = "`false`"
+":supports_online" = "`false`"
+":docstring" = "Poisson regression fitting λ with max likelihood.\n→ based on [EvoTrees](https://github.com/Evovest/EvoTrees.jl).\n→ do `@load EvoTreeCount pkg=\"EvoTrees\"` to use the model.\n→ do `?EvoTreeCount` for documentation."
+":name" = "EvoTreeCount"
+":is_supervised" = "`true`"
+":prediction_type" = ":probabilistic"
+":implemented_methods" = [":predict"]
+":hyperparameters" = "`(:loss, :nrounds, :λ, :γ, :η, :max_depth, :min_weight, :rowsample, :colsample, :nbins, :α, :metric, :seed)`"
+":hyperparameter_types" = "`(\"EvoTrees.ModelType\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"AbstractFloat\", \"AbstractFloat\", \"Int64\", \"AbstractFloat\", \"Symbol\", \"Int64\")`"
+":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
+
 [MLJModels.ConstantClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:Union{Missing, ScientificTypes.Found})`"
-":target_scitype" = "`AbstractArray{_s53,1} where _s53<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s52,1} where _s52<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MLJModels"
 ":package_license" = "MIT"
@@ -2188,7 +2272,7 @@
 ":name" = "ConstantClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":fit", ":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fit", ":fit", ":fitted_params"]
 ":hyperparameters" = "``"
 ":hyperparameter_types" = "``"
 ":hyperparameter_ranges" = "``"
@@ -2214,7 +2298,7 @@
 
 [MLJModels.DeterministicConstantClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:Union{Missing, ScientificTypes.Found})`"
-":target_scitype" = "`AbstractArray{_s53,1} where _s53<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s52,1} where _s52<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MLJModels"
 ":package_license" = "MIT"
@@ -2228,7 +2312,7 @@
 ":name" = "DeterministicConstantClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "``"
 ":hyperparameter_types" = "``"
 ":hyperparameter_ranges" = "``"
@@ -2287,7 +2371,7 @@
 ":name" = "ConstantRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fitted_params", ":predict"]
+":implemented_methods" = [":predict", ":fitted_params"]
 ":hyperparameters" = "`(:distribution_type,)`"
 ":hyperparameter_types" = "`(\"Type{D} where D<:Distributions.Sampleable\",)`"
 ":hyperparameter_ranges" = "`(nothing,)`"
@@ -2312,8 +2396,8 @@
 ":hyperparameter_ranges" = "`(nothing,)`"
 
 [MLJModels.UnivariateDiscretizer]
-":input_scitype" = "`AbstractArray{_s114,1} where _s114<:ScientificTypes.Continuous`"
-":output_scitype" = "`AbstractArray{_s113,1} where _s113<:ScientificTypes.OrderedFactor`"
+":input_scitype" = "`AbstractArray{_s113,1} where _s113<:ScientificTypes.Continuous`"
+":output_scitype" = "`AbstractArray{_s112,1} where _s112<:ScientificTypes.OrderedFactor`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MLJModels"
 ":package_license" = "MIT"
@@ -2365,13 +2449,13 @@
 ":name" = "DeterministicConstantRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "``"
 ":hyperparameter_types" = "``"
 ":hyperparameter_ranges" = "``"
 
 [MLJModels.UnivariateStandardizer]
-":input_scitype" = "`AbstractArray{_s114,1} where _s114<:ScientificTypes.Infinite`"
+":input_scitype" = "`AbstractArray{_s113,1} where _s113<:ScientificTypes.Infinite`"
 ":output_scitype" = "`AbstractArray{ScientificTypes.Continuous,1}`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "MLJModels"
@@ -2405,14 +2489,14 @@
 ":name" = "EpsilonSVR"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "`(:kernel, :gamma, :epsilon, :cost, :degree, :coef0, :tolerance, :shrinking)`"
 ":hyperparameter_types" = "`(\"LIBSVM.Kernel.KERNEL\", \"Float64\", \"Float64\", \"Float64\", \"Int32\", \"Float64\", \"Float64\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [LIBSVM.LinearSVC]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "LIBSVM"
 ":package_license" = "unknown"
@@ -2426,7 +2510,7 @@
 ":name" = "LinearSVC"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "`(:solver, :weights, :tolerance, :cost, :p, :bias)`"
 ":hyperparameter_types" = "`(\"LIBSVM.Linearsolver.LINEARSOLVER\", \"Union{Nothing, Dict}\", \"Float64\", \"Float64\", \"Float64\", \"Float64\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing)`"
@@ -2447,14 +2531,14 @@
 ":name" = "NuSVR"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "`(:kernel, :gamma, :nu, :cost, :degree, :coef0, :tolerance, :shrinking)`"
 ":hyperparameter_types" = "`(\"LIBSVM.Kernel.KERNEL\", \"Float64\", \"Float64\", \"Float64\", \"Int32\", \"Float64\", \"Float64\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [LIBSVM.NuSVC]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "LIBSVM"
 ":package_license" = "unknown"
@@ -2468,14 +2552,14 @@
 ":name" = "NuSVC"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "`(:kernel, :gamma, :weights, :nu, :cost, :degree, :coef0, :tolerance, :shrinking)`"
 ":hyperparameter_types" = "`(\"LIBSVM.Kernel.KERNEL\", \"Float64\", \"Union{Nothing, Dict}\", \"Float64\", \"Float64\", \"Int32\", \"Float64\", \"Float64\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [LIBSVM.SVC]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "LIBSVM"
 ":package_license" = "unknown"
@@ -2489,14 +2573,14 @@
 ":name" = "SVC"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":deterministic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "`(:kernel, :gamma, :weights, :cost, :degree, :coef0, :tolerance, :shrinking, :probability)`"
 ":hyperparameter_types" = "`(\"LIBSVM.Kernel.KERNEL\", \"Float64\", \"Union{Nothing, Dict}\", \"Float64\", \"Int32\", \"Float64\", \"Float64\", \"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)`"
 
 [LIBSVM.OneClassSVM]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":output_scitype" = "`AbstractArray{_s671,1} where _s671<:ScientificTypes.Finite{2}`"
+":output_scitype" = "`AbstractArray{_s656,1} where _s656<:ScientificTypes.Finite{2}`"
 ":is_pure_julia" = "`false`"
 ":package_name" = "LIBSVM"
 ":package_license" = "unknown"
@@ -2515,7 +2599,7 @@
 
 [GLM.LinearBinaryClassifier]
 ":input_scitype" = "`ScientificTypes.Table{_s23} where _s23<:(AbstractArray{_s25,1} where _s25<:ScientificTypes.Continuous)`"
-":target_scitype" = "`AbstractArray{_s1300,1} where _s1300<:ScientificTypes.Finite`"
+":target_scitype" = "`AbstractArray{_s1285,1} where _s1285<:ScientificTypes.Finite`"
 ":is_pure_julia" = "`true`"
 ":package_name" = "GLM"
 ":package_license" = "MIT"
@@ -2529,7 +2613,7 @@
 ":name" = "LinearBinaryClassifier"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":predict", ":predict_mean"]
+":implemented_methods" = [":predict", ":fit", ":predict_mean"]
 ":hyperparameters" = "`(:fit_intercept, :link)`"
 ":hyperparameter_types" = "`(\"Bool\", \"GLM.Link01\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing)`"
@@ -2550,7 +2634,7 @@
 ":name" = "LinearCountRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "`(:fit_intercept, :distribution, :link)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Distributions.Distribution\", \"GLM.Link\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing, nothing)`"
@@ -2571,7 +2655,7 @@
 ":name" = "LinearRegressor"
 ":is_supervised" = "`true`"
 ":prediction_type" = ":probabilistic"
-":implemented_methods" = [":fit", ":predict"]
+":implemented_methods" = [":predict", ":fit"]
 ":hyperparameters" = "`(:fit_intercept, :allowrankdeficient)`"
 ":hyperparameter_types" = "`(\"Bool\", \"Bool\")`"
 ":hyperparameter_ranges" = "`(nothing, nothing)`"

--- a/src/registry/Models.toml
+++ b/src/registry/Models.toml
@@ -7,6 +7,7 @@ MultivariateStats = ["ICA", "BayesianLDA", "BayesianSubspaceLDA", "RidgeRegresso
 DecisionTree = ["AdaBoostStumpClassifier", "DecisionTreeRegressor", "DecisionTreeClassifier", "RandomForestRegressor", "RandomForestClassifier"]
 Clustering = ["KMeans", "KMedoids"]
 XGBoost = ["XGBoostCount", "XGBoostRegressor", "XGBoostClassifier"]
+EvoTrees = ["EvoTreeClassifier", "EvoTreeGaussian", "EvoTreeRegressor", "EvoTreeCount"]
 MLJModels = ["ConstantClassifier", "Standardizer", "DeterministicConstantClassifier", "OneHotEncoder", "UnivariateBoxCoxTransformer", "ConstantRegressor", "FeatureSelector", "UnivariateDiscretizer", "FillImputer", "DeterministicConstantRegressor", "UnivariateStandardizer"]
 LIBSVM = ["EpsilonSVR", "LinearSVC", "NuSVR", "NuSVC", "SVC", "OneClassSVM"]
 GLM = ["LinearBinaryClassifier", "LinearCountRegressor", "LinearRegressor"]

--- a/src/registry/Project.toml
+++ b/src/registry/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
+EvoTrees = "f6006082-12f8-11e9-0c9c-0d5d367ab1e5"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
@@ -17,7 +18,7 @@ XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [compat]
 MLJBase = "^0.11"
-MLJModelInterface = "^0.1"
+MLJModelInterface = "^0.1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/registry/src/Registry.jl
+++ b/src/registry/src/Registry.jl
@@ -125,8 +125,9 @@ function _update(mod, test_env_only)
     mod.eval(program1)
     test_env_only || mod.eval(program2)
 
-    println("If you have called @update from the REPL then your namespace "*
-            "is now polluted. Restart your REPL. ")
+    println("You can now check the registry by running "*
+            "`MLJModels.check_registry().\n\n"*
+            "You can safely ignore \"conflicting import\" warnings. ")
 
     true
 end

--- a/src/registry/src/check_registry.jl
+++ b/src/registry/src/check_registry.jl
@@ -20,3 +20,4 @@ function check_registry()
         end
     end
 end
+

--- a/test/DecisionTree.jl
+++ b/test/DecisionTree.jl
@@ -4,6 +4,8 @@ using Test
 import CategoricalArrays
 import CategoricalArrays.categorical
 using MLJBase
+using Random
+Random.seed!(1234)
 
 # load code to be tested:
 import MLJModels


### PR DESCRIPTION
(**enhancement**) Add the boosted tree models from the pure-julia package [EvoTrees.jl](https://github.com/Evovest/EvoTrees.jl): `EvoTreeRegressor`, `EvoTreeGaussian`, `EvoTreeCount` and `EvoTreeClassifier` ([MLJ #122](https://github.com/alan-turing-institute/MLJ.jl/issues/122))