### PR TITLE
compatible with tablesv1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ Parameters = "^0.12"
 Requires = "^0.5, ^1"
 ScientificTypes = "^0.7"
 StatsBase = "^0.32"
-Tables = "^0.2"
+Tables = "^0.2,^1.0"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModels"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"


### PR DESCRIPTION
This is a simple update of the Project.toml to be compatible with Tables 1.0 (as well as 0.2). This was tested locally with a similar change made to MLJBase.

It can be merged after https://github.com/alan-turing-institute/MLJBase.jl/pull/204 has been merged and released.

**Note**: also a bump in patch number.