### PR TITLE
Add fields in Standardizer, support callable in features field

### DIFF
--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -322,10 +322,11 @@ MLJBase.inverse_transform(transformer::UnivariateStandardizer, fitresult, w) =
      Standardizer(; features=Symbol[], ignore=false, ordered_factor=false, count=false)
 
 Unsupervised model for standardizing (whitening) the columns of tabular data.
-If features is empty then all columns v having Continuous element scitype are standardized.
-Otherwise, the features standardized are `Continuous` named in features (`ignore=false`) or
-`Continuous` features not named in features (`ignore=true`). To allow standarization of
-`Count` or `OrderedFactor` features as well, set the appropriate flag to true.
+If features is empty then all columns `v` having Continuous element scitype are
+standardized. Otherwise, the features standardized are `Continuous` named in features
+(`ignore=false`) or `Continuous` features not named in features (`ignore=true`). To allow
+standarization of `Count` or `OrderedFactor` features as well, set the appropriate flag to
+true.
 
 Instead of supplying a features vector, a Bool-valued callable can be also be specified.
 For example, specifying `Standardizer(features = name -> name in [:x1, :x3], ignore = true,

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -319,7 +319,7 @@ MLJBase.inverse_transform(transformer::UnivariateStandardizer, fitresult, w) =
 ## STANDARDIZATION OF ORDINAL FEATURES OF TABULAR DATA
 
 """
-     Standardizer(; features=Symbol[], ignore=false)
+     Standardizer(; features=Symbol[], ignore=false, ordered_factor=false, count=false)
 
 Unsupervised model for standardizing (whitening) the columns of tabular data.
 If features is empty then all columns v having Continuous element scitype are standardized.

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -448,6 +448,8 @@ function MLJBase.fit(transformer::Standardizer, verbosity::Int, X)
     end
     fitresult_given_feature = Dict{Symbol,Tuple{Float64,Float64}}()
 
+    isempty(cols_to_fit) && @warn "No features left to standarize."
+
     # fit each feature
     verbosity < 2 || @info "Features standarized: "
     for j in cols_to_fit

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -319,13 +319,13 @@ MLJBase.inverse_transform(transformer::UnivariateStandardizer, fitresult, w) =
 ## STANDARDIZATION OF ORDINAL FEATURES OF TABULAR DATA
 
 """
-     Standardizer(; features=Symbol[], features_ignored=Symbol[])
+     Standardizer(; features=Symbol[], ignore=Symbol[])
 
 Unsupervised model for standardizing (whitening) the columns of
 tabular data. If `features` is empty then all columns `v` for which
 all elements have `Continuous` scitypes are standardized. For
 different behaviour (e.g. standardizing counts as well), specify the
-names of features to be standardized. If `features_ignored` is empty,
+names of features to be standardized. If `ignore` is empty,
 all features (or features specified in `features`) will be used,
 otherwise, ignore specified features.
 
@@ -345,19 +345,19 @@ otherwise, ignore specified features.
 """
 @with_kw_noshow mutable struct Standardizer <: Unsupervised
     features::Vector{Symbol} = Symbol[] # features to be standardized; empty means all
-    features_ignored::Vector{Symbol} = Symbol[] # features to be ignored
+    ignore::Vector{Symbol} = Symbol[] # features to be ignored
 end
 
 function MLJBase.fit(transformer::Standardizer, verbosity::Int, X)
     all_features = Tables.schema(X).names
     mach_types   = collect(eltype(selectcols(X, c)) for c in all_features)
 
-    issubset(transformer.features_ignored, all_features) ||
+    issubset(transformer.ignore, all_features) ||
         @warn "Some ignored features not present in table to be fit. "
     # determine indices of all_features to be transformed
     if isempty(transformer.features)
         cols_to_fit = filter!(eachindex(all_features) |> collect) do j
-            !(all_features[j] in transformer.features_ignored) &&
+            !(all_features[j] in transformer.ignore) &&
                 mach_types[j] <: AbstractFloat
         end
     else
@@ -365,7 +365,7 @@ function MLJBase.fit(transformer::Standardizer, verbosity::Int, X)
             @warn "Some specified features not present in table to be fit. "
         cols_to_fit = filter!(eachindex(all_features) |> collect) do j
             all_features[j] in transformer.features &&
-                !(all_features[j] in transformer.features_ignored) &&
+                !(all_features[j] in transformer.ignore) &&
                 mach_types[j] <: Real
         end
     end

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -321,13 +321,17 @@ MLJBase.inverse_transform(transformer::UnivariateStandardizer, fitresult, w) =
 """
      Standardizer(; features=Symbol[], ignore=false)
 
-Unsupervised model for standardizing (whitening) the columns of
-tabular data. If `features` is empty then all columns `v` for which
-all elements have `Continuous` scitypes are standardized. For
-different behaviour (e.g. standardizing counts as well), specify the
-names of features to be standardized. If `ignore` is empty,
-all features (or features specified in `features`) will be used,
-otherwise, ignore specified features.
+Unsupervised model for standardizing (whitening) the columns of tabular data.
+If features is empty then all columns v having Continuous element scitype are standardized.
+Otherwise, the features standardized are those named in features (ignore=false) or those
+not named in features (ignore=true). To allow standarization of Count or OrderedFactor
+features as well, set the appropriate flag to true.
+
+Instead of supplying a features vector, a Bool-valued callable can be also be specified.
+For example, specifying Standardizer(features = name -> name in [:x1, :x3], ignore = true,
+count=true) has the same effect as Standardizer(features = [:x1, :x3], ignore = true,
+count=true), namely to standardise all Continuous and Count features, with the exception
+of :x1 and :x3.
 
     using DataFrames
     X = DataFrame(x1=[0.2, 0.3, 1.0], x2=[4, 2, 3])

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -319,20 +319,21 @@ MLJBase.inverse_transform(transformer::UnivariateStandardizer, fitresult, w) =
 ## STANDARDIZATION OF ORDINAL FEATURES OF TABULAR DATA
 
 """
-     Standardizer(; features=Symbol[], ignore=false, ordered_factor=false, count=false)
+    Standardizer(; features=Symbol[], ignore=false, ordered_factor=false, count=false)
 
 Unsupervised model for standardizing (whitening) the columns of tabular data.
 If features is empty then all columns `v` having Continuous element scitype are
-standardized. Otherwise, the features standardized are `Continuous` named in features
-(`ignore=false`) or `Continuous` features not named in features (`ignore=true`). To allow
-standarization of `Count` or `OrderedFactor` features as well, set the appropriate flag to
-true.
+standardized. Otherwise, the features standardized are `Continuous` named in
+features (`ignore=false`) or `Continuous` features not named in features
+(`ignore=true`). To allow standarization of `Count` or `OrderedFactor` features
+as well, set the appropriate flag to true.
 
-Instead of supplying a features vector, a Bool-valued callable can be also be specified.
-For example, specifying `Standardizer(features = name -> name in [:x1, :x3], ignore = true,
-count=true)` has the same effect as `Standardizer(features = [:x1, :x3], ignore = true,
-count=true)`, namely to standardise all `Continuous` and `Count` features, with the
-exception of `:x1` and `:x3`.
+Instead of supplying a features vector, a Bool-valued callable can be also be
+specified. For example, specifying `Standardizer(features = name -> name in
+[:x1, :x3], ignore = true, count=true)` has the same effect as
+`Standardizer(features = [:x1, :x3], ignore = true, count=true)`, namely to
+standardise all `Continuous` and `Count` features, with the exception of `:x1`
+and `:x3`.
 
 # Example
 
@@ -410,8 +411,8 @@ function MLJBase.fit(transformer::Standardizer, verbosity::Int, X)
     #  Continuous
 
     # julia> push!(scitypes, OrderedFactor)
-    # ERROR: MethodError: Cannot `convert` an object of type Type{OrderedFactor} to an
-    # object of type DataType
+    # ERROR: MethodError: Cannot `convert` an object of type Type{OrderedFactor}
+    # to an object of type DataType
     scitypes = Vector{Any}([Continuous])
     transformer.ordered_factor && push!(scitypes, OrderedFactor)
     transformer.count && push!(scitypes, Count)

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -141,7 +141,7 @@ end
     @test MLJBase.std(Xnew[5]) ≈ 1.0
 
     # test on ignoring a feature, even if it's listed in the `features`
-    stand.features_ignored = [:x5]
+    stand.ignore = [:x5]
     f,   = MLJBase.fit(stand, 1, X)
     Xnew = MLJBase.transform(stand, f, X)
     f,   = MLJBase.fit(stand, 1, X)
@@ -159,9 +159,8 @@ end
     stand = Standardizer(features=[:x1, :mickey_mouse])
     @test_logs (:warn, r"Some specified") MLJBase.fit(stand, 1, X)
 
-    stand = Standardizer(features_ignored=[:x1, :mickey_mouse])
+    stand = Standardizer(ignore=[:x1, :mickey_mouse])
     @test_logs (:warn, r"Some ignored") MLJBase.fit(stand, 1, X)
-
 
     infos = MLJBase.info_dict(stand)
 

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -104,7 +104,7 @@ end
     N = 5
     X = (OverallQual  = rand(UInt8, N),
          GrLivArea    = rand(N),
-         Neighborhood = categorical(rand("abc", N)),
+         Neighborhood = categorical(rand("abc", N), ordered=true),
          x1stFlrSF    = rand(N),
          TotalBsmtSF  = rand(N))
 
@@ -145,12 +145,12 @@ end
     f,   = MLJBase.fit(stand, 1, X)
     Xnew = MLJBase.transform(stand, f, X)
 
-    @test issubset(Set(keys(f)), Set(Tables.schema(X).names[[5,]]))
+    @test issubset(Set(keys(f)), Set(Tables.schema(X).names[[2,]]))
 
     Xt = MLJBase.transform(stand, f, X)
 
     @test Xnew[1] == X[1]
-    @test Xnew[2] == X[2]
+    @test MLJBase.std(Xnew[2]) ≈ 1.0
     @test Xnew[3] == X[3]
     @test Xnew[4] == X[4]
     @test Xnew[5] == X[5]
@@ -163,18 +163,20 @@ end
 
     @test_throws ArgumentError Standardizer(ignore=true)
 
-    stand = Standardizer(features=[:x4], count=true)
+    stand = Standardizer(features=[:x3, :x4], count=true, ordered_factor=true)
     f,   = MLJBase.fit(stand, 1, X)
     Xnew = MLJBase.transform(stand, f, X)
-
-    @test issubset(Set(keys(f)), Set(Tables.schema(X).names[[4,]]))
+    @test issubset(Set(keys(f)), Set(Tables.schema(X).names[3:4,]))
 
     Xt = MLJBase.transform(stand, f, X)
 
     @test Xnew[1] == X[1]
     @test Xnew[2] == X[2]
-    @test Xnew[3] == X[3]
+    @test elscitype(X[3]) <: OrderedFactor
+    @test elscitype(Xnew[3]) <: Continuous
+    @test MLJBase.std(Xnew[3]) ≈ 1.0
     @test elscitype(X[4]) == Count
+    @test elscitype(Xnew[4]) <: Continuous
     @test MLJBase.std(Xnew[4]) ≈ 1.0
     @test Xnew[5] == X[5]
 

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -141,7 +141,7 @@ end
     @test MLJBase.std(Xnew[5]) ≈ 1.0
 
     # test on ignoring a feature, even if it's listed in the `features`
-    stand.ignore = [:x5]
+    stand.ignore = true
     f,   = MLJBase.fit(stand, 1, X)
     Xnew = MLJBase.transform(stand, f, X)
     f,   = MLJBase.fit(stand, 1, X)
@@ -159,8 +159,10 @@ end
     stand = Standardizer(features=[:x1, :mickey_mouse])
     @test_logs (:warn, r"Some specified") MLJBase.fit(stand, 1, X)
 
-    stand = Standardizer(ignore=[:x1, :mickey_mouse])
-    @test_logs (:warn, r"Some ignored") MLJBase.fit(stand, 1, X)
+    stand.ignore = true
+    @test_logs (:warn, r"Some specified") MLJBase.fit(stand, 1, X)
+
+    @test_throws ArgumentError Standardizer(ignore=true)
 
     infos = MLJBase.info_dict(stand)
 

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -156,7 +156,11 @@ end
     @test Xnew[5] == X[5]
 
     stand = Standardizer(features=[:x1, :mickey_mouse])
-    @test_logs (:warn, r"Some specified") MLJBase.fit(stand, 1, X)
+    @test_logs(
+        (:warn, r"Some specified"),
+        (:warn, r"No features left"),
+        MLJBase.fit(stand, 1, X)
+    )
 
     stand.ignore = true
     @test_logs (:warn, r"Some specified") MLJBase.fit(stand, 1, X)

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -140,8 +140,28 @@ end
     @test Xnew[4] == X[4]
     @test MLJBase.std(Xnew[5]) ≈ 1.0
 
+    # test on ignoring a feature, even if it's listed in the `features`
+    stand.features_ignored = [:x5]
+    f,   = MLJBase.fit(stand, 1, X)
+    Xnew = MLJBase.transform(stand, f, X)
+    f,   = MLJBase.fit(stand, 1, X)
+
+    @test issubset(Set(keys(f)), Set(Tables.schema(X).names[[5,]]))
+
+    Xt = MLJBase.transform(stand, f, X)
+
+    @test Xnew[1] == X[1]
+    @test Xnew[2] == X[2]
+    @test Xnew[3] == X[3]
+    @test Xnew[4] == X[4]
+    @test Xnew[5] == X[5]
+
     stand = Standardizer(features=[:x1, :mickey_mouse])
     @test_logs (:warn, r"Some specified") MLJBase.fit(stand, 1, X)
+
+    stand = Standardizer(features_ignored=[:x1, :mickey_mouse])
+    @test_logs (:warn, r"Some ignored") MLJBase.fit(stand, 1, X)
+
 
     infos = MLJBase.info_dict(stand)
 

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -3,6 +3,7 @@ module TestTransformer
 using Test, MLJModels
 using Tables, CategoricalArrays, Random
 using ScientificTypes
+using StatsBase
 
 import MLJBase
 
@@ -102,19 +103,20 @@ end
 
 @testset "Standardizer" begin
     N = 5
+    rand_char = rand("abcefgh", N)
+    while length(unique(rand_char)) < 2
+        rand_char = rand("abcefgh", N)
+    end
     X = (OverallQual  = rand(UInt8, N),
          GrLivArea    = rand(N),
-         Neighborhood = categorical(rand("abc", N), ordered=true),
-         x1stFlrSF    = rand(N),
+         Neighborhood = categorical(rand_char, ordered=true),
+         x1stFlrSF    = sample(1:10, N, replace=false),
          TotalBsmtSF  = rand(N))
 
     # introduce a field of type `Char`:
     x1 = categorical(map(Char, (X.OverallQual |> collect)))
 
-    # introduce field of Int type:
-    x4 = [round(Int, x) for x in X.x1stFlrSF]
-
-    X = (x1=x1, x2=X[2], x3=X[3], x4=x4, x5=X[5])
+    X = (x1=x1, x2=X[2], x3=X[3], x4=X[4], x5=X[5])
 
     stand = Standardizer()
     f,    = MLJBase.fit(stand, 1, X)

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -2,6 +2,7 @@ module TestTransformer
 
 using Test, MLJModels
 using Tables, CategoricalArrays, Random
+using ScientificTypes
 
 import MLJBase
 
@@ -128,7 +129,6 @@ end
     stand.features = [:x1, :x5]
     f,   = MLJBase.fit(stand, 1, X)
     Xnew = MLJBase.transform(stand, f, X)
-    f,   = MLJBase.fit(stand, 1, X)
 
     @test issubset(Set(keys(f)), Set(Tables.schema(X).names[[5,]]))
 
@@ -144,7 +144,6 @@ end
     stand.ignore = true
     f,   = MLJBase.fit(stand, 1, X)
     Xnew = MLJBase.transform(stand, f, X)
-    f,   = MLJBase.fit(stand, 1, X)
 
     @test issubset(Set(keys(f)), Set(Tables.schema(X).names[[5,]]))
 
@@ -163,6 +162,21 @@ end
     @test_logs (:warn, r"Some specified") MLJBase.fit(stand, 1, X)
 
     @test_throws ArgumentError Standardizer(ignore=true)
+
+    stand = Standardizer(features=[:x4], count=true)
+    f,   = MLJBase.fit(stand, 1, X)
+    Xnew = MLJBase.transform(stand, f, X)
+
+    @test issubset(Set(keys(f)), Set(Tables.schema(X).names[[4,]]))
+
+    Xt = MLJBase.transform(stand, f, X)
+
+    @test Xnew[1] == X[1]
+    @test Xnew[2] == X[2]
+    @test Xnew[3] == X[3]
+    @test elscitype(X[4]) == Count
+    @test MLJBase.std(Xnew[4]) ≈ 1.0
+    @test Xnew[5] == X[5]
 
     infos = MLJBase.info_dict(stand)
 

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -178,6 +178,16 @@ end
     @test MLJBase.std(Xnew[4]) ≈ 1.0
     @test Xnew[5] == X[5]
 
+    stand = Standardizer(features= x-> x == (:x2))
+    f,    = MLJBase.fit(stand, 1, X)
+    Xnew  = MLJBase.transform(stand, f, X)
+
+    @test Xnew[1] == X[1]
+    @test MLJBase.std(Xnew[2]) ≈ 1.0
+    @test Xnew[3] == X[3]
+    @test Xnew[4] == X[4]
+    @test Xnew[5] == X[5]
+
     infos = MLJBase.info_dict(stand)
 
     @test infos[:name] == "Standardizer"


### PR DESCRIPTION
`features` field is now accepting callable that returns Bool. That is, if `features(ftr)`, where `ftr` is a feature, returns true `ftr` is standardized.

Added `Bool` fields:
* `ignore` - if true, specified or evaluated features from `features` field are ignored.
* `ordered_factor` - if true, also standardizes `OrderedFactor` type
* `count` - if true, also standardizes `Count` type