### PR TITLE
Remove Compat.jl as explicit dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CategoricalArrays = "^0.7"
-Compat = "^2"
 Distances = "^0.8"
 Distributions = "^0.22,^0.23"
 MLJBase = "^0.12"

--- a/src/ScikitLearn/ensemble.jl
+++ b/src/ScikitLearn/ensemble.jl
@@ -111,7 +111,7 @@ GradientBoostingRegressor_ = SKEN.GradientBoostingRegressor
     verbose::Int                   = 0
     max_leaf_nodes::Option{Int}    = nothing::(_===nothing || _>0)
     warm_start::Bool               = false
-    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
+#    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
     validation_fraction::Float64   = 0.1::(_>0)
     n_iter_no_change::Option{Int}  = nothing
     tol::Float64                   = 1e-4::(_>0)
@@ -144,7 +144,7 @@ GradientBoostingClassifier_ = SKEN.GradientBoostingClassifier
     verbose::Int                   = 0
     max_leaf_nodes::Option{Int}    = nothing::(_===nothing || _>0)
     warm_start::Bool               = false
-    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
+#    presort::Union{Bool,String}    = "auto"::(isa(_, Bool) || _ == "auto")
     validation_fraction::Float64   = 0.1::(_>0)
     n_iter_no_change::Option{Int}  = nothing
     tol::Float64                   = 1e-4::(_>0)


### PR DESCRIPTION
#160 
 
Also remove `presort` hyperparameter in scikit-learn ensemble models to eliminate depreciation warnings. 

 