### PR TITLE
For a 0.9.5 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModels"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -736,7 +736,7 @@ function MLJBase.transform(transformer::OneHotEncoder, fitresult, X)
         error("Attempting to transform table with feature "*
               "labels not seen in fit. ")
     new_features = Symbol[]
-    new_cols = Vector[]
+    new_cols = [] # not Vector[] !!
     features_to_be_transformed = keys(d)
     for ftr in features
         col = MLJBase.selectcols(X, ftr)

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -267,6 +267,9 @@ end
     Xt = MLJBase.transform(t, f, X)
     @test :name in Tables.schema(Xt).names
     @test :favourite_number__5 in Tables.schema(Xt).names
+    @test MLJBase.schema(Xt).scitypes == (OrderedFactor{3}, Continuous,
+                                          Continuous, Continuous,
+                                          Continuous, Count)
 
     # test that one may not add new columns:
     X = (name       = categorical(["Ben", "John", "Mary", "John"], ordered=true),


### PR DESCRIPTION
Fix a bug in `OneHotEncoder`: If `ordered_factor=false` any `OrderedFactor` column is being changed from a  `CategoricalVector` to a `Vector` of categorical elements, instead of being left-alone (which was changing the scitype ).