### PR TITLE
Add ContinuousEncoder

### DIFF
--- a/src/MLJModels.jl
+++ b/src/MLJModels.jl
@@ -26,8 +26,9 @@ export ConstantRegressor, ConstantClassifier,
         DeterministicConstantRegressor, DeterministicConstantClassifier
 
 # from model/Transformers
-export FeatureSelector, StaticTransformer, UnivariateDiscretizer, UnivariateStandardizer,
-        Standardizer, UnivariateBoxCoxTransformer, OneHotEncoder, FillImputer
+export FeatureSelector, StaticTransformer, UnivariateDiscretizer,
+    UnivariateStandardizer, Standardizer, UnivariateBoxCoxTransformer,
+    OneHotEncoder, ContinuousEncoder, FillImputer
 
 const srcdir = dirname(@__FILE__) # the directory containing this file
 

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -321,12 +321,13 @@ MLJBase.inverse_transform(transformer::UnivariateStandardizer, fitresult, w) =
 """
     Standardizer(; features=Symbol[], ignore=false, ordered_factor=false, count=false)
 
-Unsupervised model for standardizing (whitening) the columns of tabular data.
-If features is empty then all columns `v` having Continuous element scitype are
-standardized. Otherwise, the features standardized are `Continuous` named in
-features (`ignore=false`) or `Continuous` features not named in features
-(`ignore=true`). To allow standarization of `Count` or `OrderedFactor` features
-as well, set the appropriate flag to true.
+Unsupervised model for standardizing (whitening) the columns of
+tabular data.  If features is empty then all columns `v` having
+Continuous element scitype are standardized. Otherwise, the features
+standardized are the `Continuous` features named in features
+(`ignore=false`) or `Continuous` features not named in features
+(`ignore=true`). To allow standarization of `Count` or `OrderedFactor`
+features as well, set the appropriate flag to true.
 
 Instead of supplying a features vector, a Bool-valued callable can be also be
 specified. For example, specifying `Standardizer(features = name -> name in

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -838,7 +838,7 @@ end
 
 Unsupervised model for arranging all features (columns) of a table to
 have `Continuous` element scitype, by applying following protocol
-applied to each feature `ftr`:
+to each feature `ftr`:
 
 - If `ftr` is already `Continuous` retain it.
 

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -795,8 +795,7 @@ end
 ## CONTINUOUS_ENCODING
 
 """
-    ContinuousEncoder(one_hot_ordered_factors=true,
-                      drop_last=false)
+    ContinuousEncoder(one_hot_ordered_factors=false, drop_last=false)
 
 Unsupervised model for arranging all features (columns) of a table to
 have `Continuous` element scitype, by applying following protocol

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -261,10 +261,18 @@ end
         MLJBase.selectcols(MLJBase.transform(t, f, X),
                            [:name__Ben, :name__John, :name__Mary, :age])
 
+    # test ignore
+    t = OneHotEncoder(features=[:name,], ignore=true)
+    f, = MLJBase.fit(t, 0, X)
+    Xt = MLJBase.transform(t, f, X)
+
     # test exclusion of ordered factors:
     t  = OneHotEncoder(ordered_factor=false)
-    f, = MLJBase.fit(t, 1, X)
+    f, = MLJBase.fit(t, 0, X)
     Xt = MLJBase.transform(t, f, X)
+    @test keys(Xt) == (:name, :height, :favourite_number__5,
+                       :favourite_number__7, :favourite_number__10, :age)
+
     @test :name in Tables.schema(Xt).names
     @test :favourite_number__5 in Tables.schema(Xt).names
     @test MLJBase.schema(Xt).scitypes == (OrderedFactor{3}, Continuous,

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -280,7 +280,7 @@ end
                                           Continuous, Count)
 
     # test that one may not add new columns:
-    X = (name       = categorical(["Ben", "John", "Mary", "John"], ordered=true),
+    X = (name = categorical(["Ben", "John", "Mary", "John"], ordered=true),
          height     = [1.85, 1.67, 1.5, 1.67],
          favourite_number = categorical([7, 5, 10, 5]),
          age        = [23, 23, 14, 23],
@@ -347,6 +347,38 @@ end
     @test Xt.x[1] == mode_
     @test Xt.y[1] == 1
     @test Xt.z[1] == 1
+end
+
+#### CONTINUOUS ENCODER ####
+
+@testset "Continuous encoder" begin
+
+    X = (name  = categorical(["Ben", "John", "Mary", "John"], ordered=true),
+         height = [1.85, 1.67, 1.5, 1.67],
+         rubbish = ["a", "b", "c", "a"],
+         favourite_number = categorical([7, 5, 10, 5]),
+         age    = [23, 23, 14, 23])
+
+    t  = ContinuousEncoder()
+    f, _, _ = @test_logs((:info, r"Some features cannot be replaced "*
+                               "with `Continuous` features and will be "*
+                               "dropped: Symbol[:rubbish]"),
+                              MLJBase.fit(t, 1, X))
+
+    Xt = MLJBase.transform(t, f, X)
+    @test scitype(Xt) <: MLJBase.Table(MLJBase.Continuous)
+    s = MLJBase.schema(Xt)
+    @test s.names == (:name, :height, :favourite_number__5,
+                      :favourite_number__7, :favourite_number__10, :age)
+
+    t  = ContinuousEncoder(drop_last=true, one_hot_ordered_factors=true)
+    f, _, r = MLJBase.fit(t, 0, X)
+    Xt = MLJBase.transform(t, f, X)
+    @test scitype(Xt) <: MLJBase.Table(MLJBase.Continuous)
+    s = MLJBase.schema(Xt)
+    @test s.names == (:name__Ben, :name__John, :height, :favourite_number__5,
+                      :favourite_number__7, :age)
+
 end
 
 end

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -360,9 +360,7 @@ end
          age    = [23, 23, 14, 23])
 
     t  = ContinuousEncoder()
-    f, _, _ = @test_logs((:info, r"Some features cannot be replaced "*
-                               "with `Continuous` features and will be "*
-                               "dropped: Symbol[:rubbish]"),
+    f, _, _ = @test_logs((:info, r"Some.*dropped\: Symbol\[\:rubbish\]"),
                               MLJBase.fit(t, 1, X))
 
     Xt = MLJBase.transform(t, f, X)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,16 @@
 using Test, MLJModels
 
-@testset "metadata" begin
-    @testset "reading and extracting model metadata" begin
-        @test include("metadata.jl")
-    end
-    @testset "model search" begin
-        @test include("model_search.jl")
-    end
-    @testset "loading model code" begin
-        @test include("loading.jl")
-    end
-end
+# @testset "metadata" begin
+#     @testset "reading and extracting model metadata" begin
+#         @test include("metadata.jl")
+#     end
+#     @testset "model search" begin
+#         @test include("model_search.jl")
+#     end
+#     @testset "loading model code" begin
+#         @test include("loading.jl")
+#     end
+# end
 
 @testset "built-in models" begin
     @testset "Constant" begin
@@ -21,42 +21,42 @@ end
     end
 end
 
-@testset "MultivariateStats  " begin
-    @test include("MultivariateStats.jl")
-end
-
-@testset "DecisionTree       " begin
-    @test include("DecisionTree.jl")
-end
-
-# @testset "GaussianProcesses  " begin
-#     @test include("GaussianProcesses.jl")
+# @testset "MultivariateStats  " begin
+#     @test include("MultivariateStats.jl")
 # end
 
-@testset "Clustering         " begin
-    @test include("Clustering.jl")
-end
+# @testset "DecisionTree       " begin
+#     @test include("DecisionTree.jl")
+# end
 
-@testset "GLM                " begin
-    @test include("GLM.jl")
-end
+# # @testset "GaussianProcesses  " begin
+# #     @test include("GaussianProcesses.jl")
+# # end
 
-@testset "ScikitLearn        " begin
-    @test include("ScikitLearn/ScikitLearn.jl")
-end
+# @testset "Clustering         " begin
+#     @test include("Clustering.jl")
+# end
 
-@testset "LIBSVM             " begin
-    @test include("LIBSVM.jl")
-end
+# @testset "GLM                " begin
+#     @test include("GLM.jl")
+# end
 
-@testset "NaiveBayes         " begin
-    @test include("NaiveBayes.jl")
-end
+# @testset "ScikitLearn        " begin
+#     @test include("ScikitLearn/ScikitLearn.jl")
+# end
 
-@testset "XGBoost" begin
-    @test include("XGBoost.jl")
-end
+# @testset "LIBSVM             " begin
+#     @test include("LIBSVM.jl")
+# end
 
-@testset "NearestNeighbors" begin
-    @test include("NearestNeighbors.jl")
-end
+# @testset "NaiveBayes         " begin
+#     @test include("NaiveBayes.jl")
+# end
+
+# @testset "XGBoost" begin
+#     @test include("XGBoost.jl")
+# end
+
+# @testset "NearestNeighbors" begin
+#     @test include("NearestNeighbors.jl")
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,16 @@
 using Test, MLJModels
 
-# @testset "metadata" begin
-#     @testset "reading and extracting model metadata" begin
-#         @test include("metadata.jl")
-#     end
-#     @testset "model search" begin
-#         @test include("model_search.jl")
-#     end
-#     @testset "loading model code" begin
-#         @test include("loading.jl")
-#     end
-# end
+@testset "metadata" begin
+    @testset "reading and extracting model metadata" begin
+        @test include("metadata.jl")
+    end
+    @testset "model search" begin
+        @test include("model_search.jl")
+    end
+    @testset "loading model code" begin
+        @test include("loading.jl")
+    end
+end
 
 @testset "built-in models" begin
     @testset "Constant" begin
@@ -21,42 +21,42 @@ using Test, MLJModels
     end
 end
 
-# @testset "MultivariateStats  " begin
-#     @test include("MultivariateStats.jl")
+@testset "MultivariateStats  " begin
+    @test include("MultivariateStats.jl")
+end
+
+@testset "DecisionTree       " begin
+    @test include("DecisionTree.jl")
+end
+
+# @testset "GaussianProcesses  " begin
+#     @test include("GaussianProcesses.jl")
 # end
 
-# @testset "DecisionTree       " begin
-#     @test include("DecisionTree.jl")
-# end
+@testset "Clustering         " begin
+    @test include("Clustering.jl")
+end
 
-# # @testset "GaussianProcesses  " begin
-# #     @test include("GaussianProcesses.jl")
-# # end
+@testset "GLM                " begin
+    @test include("GLM.jl")
+end
 
-# @testset "Clustering         " begin
-#     @test include("Clustering.jl")
-# end
+@testset "ScikitLearn        " begin
+    @test include("ScikitLearn/ScikitLearn.jl")
+end
 
-# @testset "GLM                " begin
-#     @test include("GLM.jl")
-# end
+@testset "LIBSVM             " begin
+    @test include("LIBSVM.jl")
+end
 
-# @testset "ScikitLearn        " begin
-#     @test include("ScikitLearn/ScikitLearn.jl")
-# end
+@testset "NaiveBayes         " begin
+    @test include("NaiveBayes.jl")
+end
 
-# @testset "LIBSVM             " begin
-#     @test include("LIBSVM.jl")
-# end
+@testset "XGBoost" begin
+    @test include("XGBoost.jl")
+end
 
-# @testset "NaiveBayes         " begin
-#     @test include("NaiveBayes.jl")
-# end
-
-# @testset "XGBoost" begin
-#     @test include("XGBoost.jl")
-# end
-
-# @testset "NearestNeighbors" begin
-#     @test include("NearestNeighbors.jl")
-# end
+@testset "NearestNeighbors" begin
+    @test include("NearestNeighbors.jl")
+end


### PR DESCRIPTION
I propose adding a new built-in transformer, called `ContinuousEncoder`, implemented in this PR, which combines one-hot encoding with coercion of `Count` data and feature dropping to ensure a table has only `Continuous` features. Multiple issues have suggest to me that users, especially beginners, would appreciate this tool. 

**edited**

Composing this transformer with just about any supervised model delivers a model that can be applied to any data, dropping only columns that are not `Count`, `Continuous`, `OrderedFactor` or `Multiclass`. I have an idea to augment the registry with "virtual" models that are ordinary models wrapped in this transformer, to dramatically expand the number of models found by `models(matching(X, y)` - but I'll invite discussion on this proposal in a separate issue.

Below is the docstring for the new transformer proposed in this PR. I will leave this unmerged until Monday at least to allow feedback, which is very much appreciated.

A review from @OkonSamuel  or @tlienart, at their leisure, would be great. 

Oh, and this PR also add the keyword `ignore` to OneHotEncoder (logic as in `Standardizer`)

---

    ContinuousEncoder(one_hot_ordered_factors=false, drop_last=false)

Unsupervised model for arranging all features (columns) of a table to
have `Continuous` element scitype, by applying following protocol
applied to each feature `ftr`:

- If `ftr` is already `Continuous` retain it.

- If `ftr` is `Multiclass`, one-hot encode it.

- If `ftr` is `OrderedFactor`, replace it with `coerce(ftr,
Continuous)` (vector of floating point integers), unless
`ordered_factors=false` is specified, in which case one-hot
encoded it.

- If `ftr` is `Count`, replace it with `coerce(ftr, Continuous)`.

- If `ftr` is of some other element scitype, or was not observed in
  fitting the encoder, drop it from the table.

If `drop_last=true` is specified, then one-hot encoding always drops
the last class indicator column.

*Warning:* This transformer assumes that the `Multiclass` or
 `OrderedFactor` features in new data to be transformed have the same
 underlying `CategoricalVector` encodings as those during the fit.

 