### PR TITLE
add `models(regex::Regex)` method

### DIFF
--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -143,10 +143,8 @@ end
 List all models whole `name` or `docstring` matches a given `needle`.
 """
 function MLJBase.models(needle::Union{AbstractString,Regex})
-    unsorted = filter(info.(keys(INFO_GIVEN_HANDLE))) do model
-        occursin(needle, model.name) || occursin(needle, model.docstring)
-    end
-    return sort!(unsorted)
+    f = model -> occursin(needle, model.name) || occursin(needle, model.docstring)
+    return MLJBase.models(f)
 end
 
 # function models(task::MLJBase.SupervisedTask)

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -137,7 +137,17 @@ function MLJBase.models(conditions...)
     return sort!(unsorted)
 end
 
-MLJBase.models() = models(x->true)
+"""
+    models(regex::Regex)
+
+List all models whole `name` or `docstring` matches a given `regex`.
+"""
+function MLJBase.models(regex::Regex)
+    unsorted = filter(info.(keys(INFO_GIVEN_HANDLE))) do model
+        occursin(regex, model.name) || occursin(regex, model.docstring)
+    end
+    return sort!(unsorted)
+end
 
 # function models(task::MLJBase.SupervisedTask)
 #     ret = Dict{String, Any}()

--- a/src/model_search.jl
+++ b/src/model_search.jl
@@ -138,13 +138,13 @@ function MLJBase.models(conditions...)
 end
 
 """
-    models(regex::Regex)
+    models(needle::Union{AbstractString,Regex})
 
-List all models whole `name` or `docstring` matches a given `regex`.
+List all models whole `name` or `docstring` matches a given `needle`.
 """
-function MLJBase.models(regex::Regex)
+function MLJBase.models(needle::Union{AbstractString,Regex})
     unsorted = filter(info.(keys(INFO_GIVEN_HANDLE))) do model
-        occursin(regex, model.name) || occursin(regex, model.docstring)
+        occursin(needle, model.name) || occursin(needle, model.docstring)
     end
     return sort!(unsorted)
 end
@@ -172,6 +172,7 @@ end
 """
     localmodels(; modl=Main)
     localmodels(conditions...; modl=Main)
+    localmodels(needle::Union{AbstractString,Regex}; modl=Main)
 
 
 List all models whose names are in the namespace of the specified

--- a/test/model_search.jl
+++ b/test/model_search.jl
@@ -36,5 +36,13 @@ end
     @test !(cnst in models(u, t))
 end
 
+@testset "models(regex::Regex) and localmodels(regex::Regex)" begin
+    @test pca in models(r"PCA")
+    @test pca in models(r"pca"i)
+    @test pca ∉ models(r"PCA′")
+
+    info("DecisionTreeRegressor") in localmodels(r"decision"; modl = TestModelSearch)
+end
+
 end
 true

--- a/test/model_search.jl
+++ b/test/model_search.jl
@@ -36,12 +36,16 @@ end
     @test !(cnst in models(u, t))
 end
 
-@testset "models(regex::Regex) and localmodels(regex::Regex)" begin
+@testset "models(needle::Union{AbstractString,Regex}) and localmodels(needle::Union{AbstractString,Regex})" begin
+    @test pca in models("PCA")
+    @test pca ∉ models("PCA′")
+
     @test pca in models(r"PCA")
     @test pca in models(r"pca"i)
     @test pca ∉ models(r"PCA′")
 
-    info("DecisionTreeRegressor") in localmodels(r"decision"; modl = TestModelSearch)
+    info("DecisionTreeRegressor") in localmodels("Decision"; modl = TestModelSearch)
+    info("DecisionTreeRegressor") in localmodels(r"Decision"; modl = TestModelSearch)
 end
 
 end


### PR DESCRIPTION
add `models(regex::Regex)` method, which would enable us to find models easily.

EDIT: I expands method signature to `needle::Union{AbstractString,Regex}`