### PR TITLE
For 0.10.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModels"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.9.13"
+version = "0.10.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"


### PR DESCRIPTION
The last minor release 0.9.13 was actually breaking because of a subtle change in the way packages are loaded (to allow glue code and model algortihms to live in different packages). 

We should probably void the 0.9.13 release after this one.