### PR TITLE
Allow @load/load to import two models with same name from different packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,10 +45,11 @@ Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 GaussianProcesses = "891a1506-143c-57d2-908e-e1f8e92e6de9"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
+MLJLinearModels = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 NaiveBayes = "9bbee03b-0db5-5f46-924f-b5c9c21b8c60"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [targets]
-test = ["Clustering", "DecisionTree", "Distances", "GLM", "GaussianProcesses", "LIBSVM", "NaiveBayes", "NearestNeighbors", "Test", "XGBoost"]
+test = ["Clustering", "DecisionTree", "Distances", "GLM", "GaussianProcesses", "LIBSVM", "MLJLinearModels", "NaiveBayes", "NearestNeighbors", "Test", "XGBoost"]

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -1,105 +1,157 @@
 ## FUNTIONS TO LOAD MODEL IMPLEMENTATION CODE
 
+# helper:
+
+
 """
-    load(name::String; pkg=nothing, modl=Main, verbosity=1, allow_ambiguous=false)
+    load(name::String; pkg=nothing, modl=Main, verbosity=1, name=nothing)
 
 Load the model implementation code for the model type with specified
-`name` into the module `modl`, specifying `pkg` if necesssary, to
-resolve duplicate names.
+`name` (first argument) into the module `modl`, specifying `pkg` if
+necesssary to resolve duplicate names. Return an instance of the model type
+with default hyper-parameters.
 
-    load(proxy; pkg=nothing, modl=Main, verbosity=1)
+To bind the name of the model type to a name different from the first
+argument, specify `name=...`.
+
+    load(proxy; kwargs...1)
 
 In the case that `proxy` is a return value of `traits` (ie, has the
 form `(name = ..., package_name = ..., etc)`) this is equivalent to
-`load(name=proxy.name, pkg=proxy.package_name)`.
-
-If `allow_ambiguous=true` then multiple models with the same name can be imported, otherwise a warning is raised and the previously available model is kept.
+`load(name=proxy.name, pkg=proxy.package_name; kwargs...)`.
 
 See also [`@load`](@ref)
 
 ### Examples
 
-    load("ConstantClassifier")
+    load("RidgeRegressor",
+         pkg="MLJLinearModels",
+         modl=MyPackage,
+         name="NewRidge",
+         verbosity=0)
+
     load(localmodels()[1])
 
 See also [`@load`](@ref)
 
 """
-function load(proxy::ModelProxy; modl=Main, verbosity=0, allow_ambiguous=false)
-    # get name, package and load path:
-    name = proxy.name
-    pkg = proxy.package_name
-    handle = (name=name, pkg=pkg)
-
-    path = INFO_GIVEN_HANDLE[handle][:load_path]
-    path_components = split(path, '.')
+function load(proxy::ModelProxy; modl=Main, verbosity=1, name=nothing)
 
     # decide what to print
     toprint = verbosity > 0
 
-    # return if model is already loaded unless allow_ambiguous
-    localnames = map(p->p.name, localmodels(modl=modl))
-    if !allow_ambiguous && name ∈ localnames
-        @info "A model type \"$name\" is already loaded. \n"*
-        "No new code loaded. "
-        return
+    # get name, package and load path:
+    model_name = proxy.name
+    pkg = proxy.package_name
+    handle = (name=model_name, pkg=pkg)
+
+    # see if the model has already been loaded:
+    type_already_loaded = handle in map(localmodels(modl=modl)) do m
+        (name=m.name, pkg=m.package_name)
     end
 
-    verbosity > 1 && @info "Loading into module \"$modl\": "
+    if type_already_loaded && name == nothing
+        toprint && @info "Model code for $model_name already loaded"
+        # return an instance of the type:
+        for M in localmodeltypes(modl)
+             i = info(M)
+            if i.name == model_name && i.package_name == pkg
+                return M()
+            end
+        end
+    end
+
+    # from now on work with symbols not strings:
+    path = INFO_GIVEN_HANDLE[handle][:load_path]
+    path_components = Symbol.(split(path, '.') )
+    model_name = Symbol(model_name)
+    pkg = Symbol(pkg)
+
+    verbosity > 0 && @info "Loading into module \"$modl\": "
+
+    # create `name`, the actual name (symbol) to be bound to the
+    # new type in the global namespace of `modl`. Note two packages
+    # might provide models with the same `model_name`.
+    if name === nothing
+        name = MLJBase.available_name(modl, Symbol(model_name))
+        name == model_name || verbosity < 0 ||
+            @warn "New model type being bound to "*
+            "`$name` to avoid conflict with an existing name. "
+    else
+        name = Symbol(name)
+    end
 
     # the package providing the implementation of the MLJ model
     # interface could be different from `pkg`, which is the package
     # name exposed to the user (and where the core alogrithms live,
     # but that this not actually relevant here).
     api_pkg = path_components[1]
-    
+
     # if needed, put MLJModels in the calling module's namespace:
-    if api_pkg == "MLJModels"
+    if api_pkg == :MLJModels
         toprint && print("import MLJModels ")
         # the latter pass exists as a fallback, and shouldn't happen
         # for end users, but we need that for testing, etc
         load_ex =
-            isdefined(modl, :MLJ) ? :(import MLJ.MLJModels) : :(import MLJModels)
+            isdefined(modl, :MLJ) ? :(import MLJ.MLJModels) :
+            :(import MLJModels)
         modl.eval(load_ex)
         toprint && println('\u2714')
     end
 
     # load `api_pkg`, unless this is MLJModels, in which case load
     # `pkg` to trigger lazy-loading of implementation code:
-    pkg_ex = api_pkg == "MLJModels" ? Symbol(pkg) : Symbol(api_pkg)
+    pkg_ex = api_pkg == :MLJModels ? pkg : api_pkg
     toprint && print("import $pkg_ex ")
     modl.eval(:(import $pkg_ex))
 
     toprint && println('\u2714')
 
     # load the model:
-    # the latter pass exists as a fallback, and shouldn't happen for end users,
-    # but we need that for testing, etc
-    load_str = (api_pkg == "MLJModels" && isdefined(modl, :MLJ)) ?
-        "import MLJ.$path" : "import $path"
-    load_ex = Meta.parse(load_str)
-    toprint && print(string(load_ex, " "))
-    modl.eval(load_ex)
+    # the latter pass exists as a fallback, and shouldn't happen for
+    # end users, but we need that for testing, etc
+    if api_pkg == "MLJModels" && isdefined(modl, :MLJ)
+        pushfirst!(path_components, :MLJ)
+    end
+    root_components = path_components[1:(end - 1)]
+    root_str = join(string.(root_components), '.')
+    import_ex = Expr(:import, Expr(:(.), root_components...))
+    path_str = join(string.(path_components), '.')
+    path_ex = path_str |> Meta.parse
+    program =
+        quote
+            $import_ex
+            const $name = $path_ex
+        end
+
+    toprint && print("import ", root_str, " ")
+    modl.eval(program)
     toprint && println('\u2714')
 
-    nothing
+    return modl.eval(:($name()))
+
 end
 
 load(name::String; pkg=nothing, kwargs...) =
     load(info(name; pkg=pkg); kwargs...)
 
 """
-    @load name pkg=nothing verbosity=0
+    @load name pkg=nothing verbosity=0 name=nothing
 
-Load the model implementation code for the model with specified `name`
-into the calling module, provided `pkg` is specified in the case of
-duplicate names.
+Load the model implementation code for the model named in the first
+argument into the calling module, specfying `pkg` in the case of
+duplicate names. Return a model instance with default
+hyper-parameters.
+
+To bind the new model type to a name different from the first
+argument, specify `name=...`.
+
 
 ### Examples
 
     @load DecisionTreeeRegressor
     @load PCA verbosity=1
-    @load SVC pkg=LIBSVM
+    @load SVC pkg=LIBSVM name=MyOtherSVC
 
 See also [`load`](@ref)
 
@@ -131,17 +183,4 @@ macro load(name_ex, kw_exs...)
 
     load(name, modl=__module__, pkg=pkg, verbosity=verbosity)
 
-    esc(quote
-            try
-                $name_ex()
-            catch
-                try # hack for baremodules that have imported Base.eval:
-                    $name_ex = Base.$name_ex
-                    $name_ex()
-                catch
-                    @warn "Code is loaded but no instance returned. "
-                    nothing
-                end
-            end
-        end)
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -4,19 +4,61 @@ module TestLoading
 using Test
 using MLJModels
 
-@testset "loading of model implementations" begin
-    tree = @load DecisionTreeClassifier pkg=DecisionTree verbosity=1
-    @test (@isdefined DecisionTreeClassifier)
-    @test tree == DecisionTreeClassifier()
-    @test_logs((:info, r"^A model"),
-               load("DecisionTreeClassifier", modl=TestLoading))
-    @test(MLJModels.info("DecisionTreeClassifier")
-          in localmodels(modl=TestLoading))
+@testset "`load` function" begin
+
+    load("RidgeRegressor",
+         pkg="MultivariateStats",
+         modl=TestLoading,
+         verbosity=1)
+
+    @test isdefined(TestLoading, :RidgeRegressor)
+    @test MLJModels.info("RidgeRegressor", pkg="MultivariateStats") in
+    localmodels(modl=TestLoading)
+
+    # load the same model again:
+    @test_logs (:info, r"Model code") begin
+        load("RidgeRegressor",
+             pkg="MultivariateStats",
+             modl=TestLoading,
+             verbosity=1)
+    end
+
+    @test !isdefined(TestLoading, :RidgeRegressor2)
+
+    # load the same model again, with a different binding:
+    load("RidgeRegressor",
+         pkg="MultivariateStats",
+         modl=TestLoading,
+         verbosity=1,
+         name="Foo")
+
+    @test Foo() == RidgeRegressor()
+
+    # load a model with same name from different package:
+    @test_logs (:warn, r"New model type") begin
+         load("RidgeRegressor",
+              pkg="MLJLinearModels",
+              modl=TestLoading,
+              verbosity=0)
+    end
+
+    @test typeof(RidgeRegressor2()) != typeof(RidgeRegressor())
+
+    # try to use the name of an existing object for new type name
+    @test_throws Exception load("DecisionTreeClassifier",
+                                pkg="DecisionTree",
+                                modl=TestLoading,
+                                verbosity=0,
+                                name="RidgeRegressor")
+end
+
+@testset "@load macro" begin
     @load PCA
+    @test isdefined(TestLoading, :PCA)
     @test_throws(ArgumentError, load("RidgeRegressor", modl=TestLoading))
-    @load RidgeRegressor pkg="MultivariateStats"
 end
 
 end # module
 
 true
+


### PR DESCRIPTION
Context: #242

New behaviour: 

- No error thrown if you try to load a model with a name clashing with an existing one. Rather the new model type is bound to a different name which is auto-generated by default (eg, `RidgeRegressor2`) with a warning issued, or bound to a name specified by a key-word argument `name=...`. 

- Previously only `@load` returned a default instance of the model; now `load` also does this. 

New doc-strings:

---

    @load name pkg=nothing verbosity=0 name=nothing

Load the model implementation code for the model named in the first
argument into the calling module, specfying `pkg` in the case of
duplicate names. Return a model instance with default
hyper-parameters.

To bind the new model type to a name different from the first
argument, specify `name=...`.


### Examples

    @load DecisionTreeeRegressor
    @load PCA verbosity=1
    @load SVC pkg=LIBSVM name=MyOtherSVC

See also [`load`](@ref)

---

    load(name::String; pkg=nothing, modl=Main, verbosity=1, name=nothing)

Load the model implementation code for the model type with specified
`name` (first argument) into the module `modl`, specifying `pkg` if
necesssary to resolve duplicate names. Return an instance of the model type
with default hyper-parameters.

To bind the name of the model type to a name different from the first
argument, specify `name=...`.

    load(proxy; kwargs...1)

In the case that `proxy` is a return value of `traits` (ie, has the
form `(name = ..., package_name = ..., etc)`) this is equivalent to
`load(name=proxy.name, pkg=proxy.package_name; kwargs...)`.

See also [`@load`](@ref)

### Examples

    load("RidgeRegressor",
         pkg="MLJLinearModels",
         modl=MyPackage,
         name="NewRidge",
         verbosity=0)

    load(localmodels()[1])

See also [`@load`](@ref)
