### PR TITLE
Update XGBoost.jl

### DIFF
--- a/src/XGBoost.jl
+++ b/src/XGBoost.jl
@@ -155,7 +155,7 @@ function XGBoostRegressor(
     ,feature_selector="cyclic"
     ,top_k=0
     ,tweedie_variance_power=1.5
-    ,objective="reg:linear"
+    ,objective="reg:squarederror"
     ,base_score=0.5
     ,eval_metric="rmse"
     ,seed=0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,8 +45,10 @@ end
     @test include("NaiveBayes.jl")
 end
 
+if VERSION >= v"1.3"
 @testset "XGBoost" begin
     @test include("XGBoost.jl")
+end
 end
 
 @testset "NearestNeighbors" begin


### PR DESCRIPTION
ref #278 

addresses the warning message:

```
WARNING: /workspace/srcdir/xgboost/src/objective/regression_obj.cu:170: reg:linear is now deprecated in favor of reg:squarederror.
```