### PR TITLE
improvements to  `FillImputer` and `UnivariateFillImputer` unsupervised models

### DIFF
--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -62,8 +62,6 @@ function MLJBase.fit(transformer::UnivariateFillImputer,
 
 end
 
-get_catval(x::CategoricalValue) = levels(pool(x))[get(pool(x), x)]
-
 function replace_missing(::Type{<:Finite}, vnew, filler)
    all(in(levels(filler)), levels(vnew)) || 
    	error(ArgumentError("The `column::AbstractVector{<:Finite}`"* 

--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -72,9 +72,10 @@ function MLJBase.transform(transformer::UnivariateFillImputer,
     "into a vector of incompatible elscitype, namely $(elscitype(vnew)). ")
 
     if Missing <: elscitype(vnew)
-        w = copy(vnew) # transform must be non-mutating
-        w[ismissing.(w)] .= filler
-        w_tight = convert.(nonmissing(eltype(w)), w)
+        w_tight = similar(vnew, nonmissing(eltype(vnew)))
+ 	@inbounds for i in eachindex(vnew)
+           ismissing(vnew[i]) ? (w_tight[i] = filler ) : (w_tight[i] = vnew[i])
+    	end
     else
         w_tight = vnew
     end


### PR DESCRIPTION
This PR
1. Makes `FillImputer` and `UnivariateFillImputer` models slightly more efficient
2. Add an error msg when applying `UnivariateFillImputer` to a  column `v` of `scitype` `AbstractVector{Union{Missing, <:Finite}}` if  the column doesn't contain the same levels as that of the categorical value `imputer` to be imputed. (i.e `all( in( levels(filler) ), levels(v) ) == true`). This implies that transforming a column of `elscitype`  `Union{Missing, OrderedFactor{N}` would always give a column of  `elscitype`  `OrderedFactor{N}`and transforming a column of `elscitype`  `Union{Missing, Multiclass{N}` would always give a column of  `elscitype`  `Multiclass{N}`.
3. The user can now specify the categorical value `filler` which is to be imputed in a column `v` of `scitype` `AbstractVector{Union{Missing, <:Finite}}` provided the categorical value `filler` to be imputed is taken from any categorical vector with the same levels as that found in `v`.
The following example shows the third point.
```julia
julia> using CategoricalArrays: pool

julia> using DataFramesjulia> using MLJ
[ Info: Precompiling MLJ [add582a8-e3ab-11e8-2d5e-e98b27df1bc7]
[ Info: Model metadata loaded from registry. 

julia> data = (b=["hello", missing, "world"],) |> DataFrame
co3×1 DataFrame
│ Row │ b       │
│     │ String? │
├─────┼─────────┤
│ 1   │ hello   │
│ 2   │ missing │
│ 3   │ world   │

julia> coerce!(data, autotype(data, :string_to_multiclass))
3×1 DataFrame
│ Row │ b       │
│     │ Cat…?   │
├─────┼─────────┤
│ 1   │ hello   │
│ 2   │ missing │
│ 3   │ world   │

julia> mode(data.b)
CategoricalValue{String,UInt32} "hello"

# specify a categorical value `lev` to be imputed. `lev` is taken from a categorical vector `x` with 
# the same levels as that found in `data.b` or `transform` will error. 
julia> get_level(x, lev) = pool(x)[get(pool(x),  lev)]    # this line edited by @ablaom
get_level (generic function with 2 methods)

# replaces `missing` with `"world"` instead of the mode (`"hello"`)
julia> mach = fit!(machine(FillImputer(features = [:b], finite_fill = e -> get_level(data.b, "world")), data))
[ Info: Training Machine{FillImputer} @384.
Machine{FillImputer} @384 trained 1 time.
  args: 
    1:	Source @123 ⏎ `Table{AbstractArray{Union{Missing, Multiclass{2}},1}}`

julia> MLJ.transform(mach, data)
3×1 DataFrame
│ Row │ b     │
│     │ Cat…  │
├─────┼───────┤
│ 1   │ hello │
│ 2   │ world │
│ 3   │ world │
```