### PR TITLE
Fix typo in docstrings of RandomForest{Regressor,Classifier}

### DIFF
--- a/src/DecisionTree.jl
+++ b/src/DecisionTree.jl
@@ -153,7 +153,7 @@ $RFC_DESCR
 
 - `max_depth=-1`:          max depth of the decision tree (-1=any)
 
-- `min_samples_leaf=1`:    max number of samples each leaf needs to have
+- `min_samples_leaf=1`:    min number of samples each leaf needs to have
 
 - `min_samples_split=2`:   min number of samples needed for a split
 
@@ -323,7 +323,7 @@ $RFC_DESCR
 
 - `max_depth=-1`:          max depth of the decision tree (-1=any)
 
-- `min_samples_leaf=1`:    max number of samples each leaf needs to have
+- `min_samples_leaf=1`:    min number of samples each leaf needs to have
 
 - `min_samples_split=2`:   min number of samples needed for a split
 


### PR DESCRIPTION
Fix typo: min number... instead of max number... for RandomForestRegressor
and RandomForestClassifier