### PR TITLE
Remove GaussianProcesses; Remove NaiveBayes testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,10 +46,9 @@ DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
-NaiveBayes = "9bbee03b-0db5-5f46-924f-b5c9c21b8c60"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [targets]
-test = ["Clustering", "DecisionTree", "Distances", "GLM", "LIBSVM", "NaiveBayes", "NearestNeighbors", "Test", "XGBoost"]
+test = ["Clustering", "DecisionTree", "Distances", "GLM", "LIBSVM", "NearestNeighbors", "Test", "XGBoost"]

--- a/Project.toml
+++ b/Project.toml
@@ -45,7 +45,6 @@ Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
-GaussianProcesses = "891a1506-143c-57d2-908e-e1f8e92e6de9"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
 NaiveBayes = "9bbee03b-0db5-5f46-924f-b5c9c21b8c60"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
@@ -53,4 +52,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 XGBoost = "009559a3-9522-5dbb-924b-0b6ed2b22bb9"
 
 [targets]
-test = ["Clustering", "DecisionTree", "Distances", "GLM", "GaussianProcesses", "LIBSVM", "NaiveBayes", "NearestNeighbors", "Test", "XGBoost"]
+test = ["Clustering", "DecisionTree", "Distances", "GLM", "LIBSVM", "NaiveBayes", "NearestNeighbors", "Test", "XGBoost"]

--- a/src/MLJModels.jl
+++ b/src/MLJModels.jl
@@ -66,8 +66,6 @@ append!(NAMES, model_names(INFO_GIVEN_HANDLE))
 function __init__()
     @require(DecisionTree="7806a523-6efd-50cb-b5f6-3fa6f1930dbb",
              include("DecisionTree.jl"))
-    @require(GaussianProcesses="891a1506-143c-57d2-908e-e1f8e92e6de9",
-             include("GaussianProcesses.jl"))
     @require(GLM="38e38edf-8417-5370-95a0-9cbb8c7f171a",
              include("GLM.jl"))
     @require(Clustering="aaaa29a8-35af-508c-8bc3-b662a17a0fe5",

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -34,8 +34,7 @@ using MLJModels
 
     @test Foo() == RidgeRegressor()
 
-    # TODO: re-instate when Optim.jl updates its [compat] for FillArrays:
-    # https://github.com/JuliaNLSolvers/Optim.jl/pull/840
+    # TODO: re-instate when only julia ^1.2 is supported. 
 
     # # load a model with same name from different package: @test_logs
     # (:warn, r"New model type") begin load("RidgeRegressor",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,9 +41,9 @@ end
     @test include("LIBSVM.jl")
 end
 
-@testset "NaiveBayes         " begin
-    @test include("NaiveBayes.jl")
-end
+# @testset "NaiveBayes         " begin
+#     @test include("NaiveBayes.jl")
+# end
 
 if VERSION >= v"1.3"
 @testset "XGBoost" begin


### PR DESCRIPTION
**edited** 

The models from `GaussianProcesses` were never properly interfaced (and hence never added to the registry).We still have it in [extras], which is leading to package conflict headaches in CI.

So this PR removes GPs. The unfinished glue code is not removed, but the corresponding `include` has been removed.

It also removes testing for NaiveBayes, which has been leading to persistent CI headaches. The NaiveBayes glue code will be moved to a separate pkg [shortly](https://github.com/alan-turing-institute/MLJNaiveBayesInterface.jl), so no big deal. 

