### PR TITLE
Add BinaryThresholdPredictor model

### DIFF
--- a/src/MLJModels.jl
+++ b/src/MLJModels.jl
@@ -25,6 +25,9 @@ export models, localmodels
 export ConstantRegressor, ConstantClassifier,
         DeterministicConstantRegressor, DeterministicConstantClassifier
 
+# from model/ThresholdPredictors
+export BinaryThresholdPredictor
+
 # from model/Transformers
 export FeatureSelector, StaticTransformer, UnivariateDiscretizer,
     UnivariateStandardizer, Standardizer, UnivariateBoxCoxTransformer,
@@ -48,6 +51,7 @@ import .Registry.@update
 # load built-in models:
 include("builtins/Constant.jl")
 include("builtins/Transformers.jl")
+include("builtins/ThresholdPredictors.jl")
 
 const INFO_GIVEN_HANDLE = Dict{Handle,Any}()
 const PKGS_GIVEN_NAME   = Dict{String,Vector{String}}()

--- a/src/builtins/ThresholdPredictors.jl
+++ b/src/builtins/ThresholdPredictors.jl
@@ -1,0 +1,156 @@
+##
+###  BinaryThresholdPredictor
+##
+"""
+    BinaryThresholdPredictor(wrapped_model=ConstantClassifier(), threshold=0.5)
+    Wraps a `Probabilistic` model(`wrapped_model`) supporting binary classification in a 
+`BinaryThresholdPredictor` model. Training the `BinaryThresholdPredictor` model results in 
+training the underlying `wrapped_model`. 
+`BinaryThresholdPredictor` model predictions are deterministic and depend on the specified 
+probability `threshold`(which lies in [0, 1) ). The positive class is predicted if the 
+probability value exceeds the threshold.
+
+Note:
+- The positive class is taken to be the last class in `levels(y)` where y
+ is the target vector.
+- The default `threshold`(0.5) predicts the modal class.
+"""
+mutable struct BinaryThresholdPredictor{M <: Probabilistic} <: Deterministic
+    wrapped_model::M
+    threshold::Float64
+end
+
+function clean!(model::BinaryThresholdPredictor)
+    if !(AbstractVector{Multiclass{2}} <: target_scitype(model.wrapped_model) || 
+        AbstractVector{OrderedFactor{2}} <: target_scitype(model.wrapped_model))
+        throw(ArgumentError("`model` has unsupported target_scitype "*
+              "`$(target_scitype(model.wrapped_model))`. "))
+    end
+    message = ""
+    if model.threshold >= 1 || model.threshold < 0
+        message = message*"`threshold` should be "*
+        "in the range [0, 1). Resetting to 0.5. "
+        model.threshold = 0.5
+    end
+    return message
+end
+
+function BinaryThresholdPredictor(;wrapped_model=ConstantClassifier(), threshold=0.5)
+    model = BinaryThresholdPredictor(wrapped_model, Float64(threshold))
+    message = clean!(model)
+    isempty(message) || @warn message
+    return model
+end
+
+function MLJBase.fit(model::BinaryThresholdPredictor, verbosity::Int, args...)
+    model_fitresult, model_cache, model_report = MLJBase.fit(
+        model.wrapped_model, verbosity-1, args...
+    )
+    cache = (wrapped_model_cache = model_cache,)
+    report = (wrapped_model_report = model_report,)
+    fitresult = (model_fitresult, model.threshold)
+    return fitresult, cache, report
+end
+
+function MLJBase.update(
+    model::BinaryThresholdPredictor, verbosity::Int, old_fitresult, old_cache, args...
+)
+    model_fitresult, model_cache, model_report = MLJBase.update(
+        model.wrapped_model, verbosity-1, old_fitresult[1], old_cache[1], args...
+    )
+    cache = (wrapped_model_cache = model_cache,)
+    report = (wrapped_model_report = model_report,)
+    fitresult = (model_fitresult, model.threshold)
+    return fitresult, cache, report
+end
+
+function MLJBase.fitted_params(model::BinaryThresholdPredictor, fitresult)
+    return (
+        threshold= fitresult[2],
+        wrapped_model_fitted_params = MLJBase.fitted_params(
+            model.wrapped_model, fitresult[1]
+        )
+    )
+end
+
+function MLJBase.predict(model::BinaryThresholdPredictor, fitresult, X)
+   yhat = MLJBase.predict(model.wrapped_model, fitresult[1], X)
+   length(yhat.prob_given_ref) == 2 || begin
+   @warn "Predicted `AbstractVector{<:UnivariateFinite}`"*
+       " contains only 1 class. Hence predictions will only contain this class "*
+       "irrrespective of the set `threshold` "
+   return mode.(yhat)
+   end
+   threshold = (1 - fitresult[2], fitresult[2])
+   return _predict_threshold(yhat, threshold)
+end
+
+_div(x,y) = ifelse( iszero(x) && x==y, Inf, x/y)
+
+function _predict_threshold(yhat::UnivariateFinite, threshold)
+    dict = yhat.prob_given_ref
+    length(threshold) == length(dict) || throw(
+        ArgumentError(
+        "`length(threshold)` has to equal number of classes in specified "*
+        "`UnivariateFinite` distribution."
+        )
+    )
+    max_prob, max_class = findmax([_div(dict[ref], threshold[ref]) for ref in keys(dict)])
+    return yhat.decoder(max_class)    
+end
+
+function _predict_threshold(yhat::AbstractArray{<:UnivariateFinite}, threshold)
+    return _predict_threshold.(yhat, (threshold,))
+end
+
+function _predict_threshold(yhat::UnivariateFiniteArray{S,V,R,P,N}, threshold) where{S,V,R,P,N}
+    dict = yhat.prob_given_ref
+    length(threshold) == length(dict) || throw(
+        ArgumentError(
+        "`length(threshold)` has to equal number of classes in specified "*
+        "`UnivariateFiniteArray`."
+        )
+    )
+    d = yhat.decoder(1)
+    levs = levels(d)
+    ord = isordered(d)
+    # Array to house the predicted classes
+    ret = CategoricalArray{V, N, R}(undef, size(yhat), levels=levs, ordered=ord)
+    #ret = Array{CategoricalValue{V, R}, N}(undef, size(yhat)) 
+    # `temp` vector allocted once to be used for calculations in each loop
+    temp = Vector{Float64}(undef, length(dict))
+    # allocate vectors of keys to enable use of @simd in innermost loop
+    #kv = keys(dict) |> collect 
+    for i in eachindex(ret)
+        #@simd for ind in eachindex(kv)
+         @simd for ref in eachindex(temp)
+           #@inbounds ref = kv[ind]
+           #@inbounds temp[ind] = _div(dict[ref][i], threshold[ref])
+           @inbounds temp[ref] = _div(dict[ref][i], threshold[ref])
+        end
+        max_prob, max_class = findmax(temp)
+        @inbounds ret[i] = yhat.decoder(max_class)
+    end
+    return ret
+end
+
+## METADATA
+
+# Note: input traits are inherited from the wrapped model
+
+MLJBase.supports_weights(::Type{<:BinaryThresholdPredictor{M}}) where M =
+    MLJBase.supports_weights(M)
+
+MLJBase.load_path(::Type{<:BinaryThresholdPredictor}) =
+    "MLJModels.BinaryThresholdPredictor"
+MLJBase.package_name(::Type{<:BinaryThresholdPredictor}) = "MLJModels"
+MLJBase.package_uuid(::Type{<:BinaryThresholdPredictor}) = ""
+MLJBase.package_url(::Type{<:BinaryThresholdPredictor}) =
+    "https://github.com/alan-turing-institute/MLJModels.jl"
+MLJBase.is_pure_julia(::Type{<:BinaryThresholdPredictor{M}}) where M =
+    MLJBase.is_pure_julia(M)
+MLJBase.input_scitype(::Type{<:BinaryThresholdPredictor{M}}) where M =
+    MLJBase.input_scitype(M)
+MLJBase.target_scitype(::Type{<:BinaryThresholdPredictor}) =
+    AbstractVector{<:Binary}
+

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -1,0 +1,108 @@
+module TestThresholdPredictors
+using Test, MLJModels, CategoricalArrays
+
+import MLJBase
+
+@testset "BinaryThresholdPredictor" begin
+    X = NamedTuple{(:x1,:x2,:x3)}((rand(10), rand(10), rand(10)))
+    yraw = ["MLJ", "ScikitLearn", "ScikitLearn", "ScikitLearn"]
+    yraw1 = ["ScikitLearn", "ScikitLearn", "ScikitLearn", "ScikitLearn"]
+    y = categorical(yraw)
+    y1 = categorical(yraw1)
+
+    model = BinaryThresholdPredictor()
+    # Check when predictions contain a single class
+    f, _, _ = MLJBase.fit(model, X, y1, X)
+    @test_logs((:warn, r"Predicted `AbstractVector{<:UnivariateFinite}`"),
+        MLJBase.predict(model, f, X))
+    @test MLJBase.predict(model, f, X) == MLJBase.predict_mode(model.wrapped_model, f[1], X)
+    # Check predictions containing two classes
+    @test_throws ArgumentError BinaryThresholdPredictor(wrapped_model=ConstantRegressor())
+    @test_logs((:warn, r"`threshold` should be"), BinaryThresholdPredictor(threshold=-1))
+    @test_logs((:warn, r"`threshold` should be"), BinaryThresholdPredictor(threshold=1))
+    # Compare fitresult and fitted_params with that of wrapped_model 
+    model_fr, model_cache, model_report = MLJBase.fit(model, 1, X, y)
+    wrapped_model_fr, wrapped_model_cache, wrapped_model_report = 
+        MLJBase.fit(model.wrapped_model, 1, X, y) 
+    @test model_fr[1] == wrapped_model_fr
+    
+    # Check model update  
+    model_up, model_cache_up, model_report_up = 
+        MLJBase.update(model, 1, model_fr, model_cache, X, y)
+    wrapped_model_up, wrapped_model_cache_up, wrapped_model_report_up = 
+        MLJBase.update(model.wrapped_model, 1, wrapped_model_fr, wrapped_model_cache, X, y)
+    @test model_up[1] == wrapped_model_up
+    @test model_cache_up[1] == wrapped_model_cache_up
+    @test model_report_up[1] == wrapped_model_report_up
+    
+    # Check fitted_params
+    @test MLJBase.fitted_params(model, model_fr).wrapped_model_fitted_params == 
+         MLJBase.fitted_params(model.wrapped_model, wrapped_model_fr)
+    
+    # Check deterministic predictions
+    @test MLJBase.predict(model, model_fr, X) == 
+        MLJBase.predict_mode(model.wrapped_model, wrapped_model_fr, X)
+     
+    model.threshold = 0.8
+    model_fr, cache, report = MLJBase.fit(model, 1, X, y)
+    @test MLJBase.predict(model, model_fr, X) == 
+        [y[1] for i in 1:10]
+
+    d = MLJBase.info_dict(model)
+    @test d[:supports_weights] == MLJBase.supports_weights(model.wrapped_model)
+    @test d[:input_scitype] == MLJBase.input_scitype(model.wrapped_model)
+    @test d[:target_scitype] == AbstractVector{<:MLJBase.Finite{2}}
+    @test d[:is_pure_julia] == MLJBase.is_pure_julia(model.wrapped_model)
+    @test d[:name] == "BinaryThresholdPredictor"
+    @test d[:load_path] == "MLJModels.BinaryThresholdPredictor"
+end
+
+@testset "_predict_threshold" begin
+    v1 = categorical([:a, :b, :a])
+    v2 = categorical([:a, :b, :a, :c])    
+    # Test with UnivariateFinite object
+    d1 = MLJBase.UnivariateFinite(MLJBase.classes(v1), [0.4, 0.6])
+    @test_throws ArgumentError MLJModels._predict_threshold(d1, 0.7)
+    @test MLJModels._predict_threshold(d1, (0.7, 0.3)) == v1[2]
+    @test MLJModels._predict_threshold(d1, [0.5, 0.5]) == v1[2]
+    @test MLJModels._predict_threshold(d1, (0.4, 0.6)) == v1[1]
+    @test MLJModels._predict_threshold(d1, [0.2, 0.8]) == v1[1]
+    d2 = MLJBase.UnivariateFinite(MLJBase.classes(v2), [0.4, 0.3, 0.3])
+    @test_throws ArgumentError MLJModels._predict_threshold(d2, (0.7, 0.3))
+    @test MLJModels._predict_threshold(d2, (0.2, 0.5, 0.3)) == v2[1]
+    @test MLJModels._predict_threshold(d2, [0.3, 0.2, 0.5]) == v2[2]
+    @test MLJModels._predict_threshold(d2, (0.4, 0.4, 0.2)) == v2[4]
+    @test MLJModels._predict_threshold(d2, [0.2, 0.5, 0.3]) == v2[1]
+    
+    # Test with Array{UnivariateFinite, 1} object
+    d1_arr = [d1 for i in 1:3]
+    @test_throws ArgumentError MLJModels._predict_threshold(d1_arr, 0.7)
+    @test MLJModels._predict_threshold(d1_arr, (0.7, 0.3)) == [v1[2] for i in 1:3]
+    @test MLJModels._predict_threshold(d1_arr, [0.5, 0.5]) == [v1[2] for i in 1:3]
+    @test MLJModels._predict_threshold(d1_arr, (0.4, 0.6)) == [v1[1] for i in 1:3]
+    @test MLJModels._predict_threshold(d1_arr, [0.2, 0.8]) == [v1[1] for i in 1:3]
+    d2_arr = [d2 for i in 1:3]
+    @test_throws ArgumentError MLJModels._predict_threshold(d2_arr, (0.7, 0.3))
+    @test MLJModels._predict_threshold(d2_arr, (0.2, 0.5, 0.3)) == [v2[1] for i in 1:3]
+    @test MLJModels._predict_threshold(d2_arr, [0.3, 0.2, 0.5]) == [v2[2] for i in 1:3]
+    @test MLJModels._predict_threshold(d2_arr, (0.4, 0.4, 0.2)) == [v2[4] for i in 1:3]
+    @test MLJModels._predict_threshold(d2_arr, [0.2, 0.5, 0.3]) == [v2[1] for i in 1:3]
+    # Test with UnivariateFiniteArray oject
+    probs1 = [0.2 0.8; 0.7 0.3; 0.1 0.9]    
+    unf_arr1 = MLJBase.UnivariateFinite(MLJBase.classes(v1), probs1)
+    @test_throws ArgumentError MLJModels._predict_threshold(unf_arr1, 0.7)
+    @test MLJModels._predict_threshold(unf_arr1, (0.7, 0.3)) == [v1[2], v1[1], v1[2]]
+    @test MLJModels._predict_threshold(unf_arr1, [0.5, 0.5]) == [v1[2], v1[1], v1[2]]
+    @test MLJModels._predict_threshold(unf_arr1, (0.4, 0.6)) == [v1[2], v1[1], v1[2]]
+    @test MLJModels._predict_threshold(unf_arr1, [0.2, 0.8]) == [v1[1], v1[1], v1[2]]
+    probs2 = [0.2 0.3 0.5;0.1 0.6 0.3; 0.4 0.0 0.6]
+    unf_arr2 = MLJBase.UnivariateFinite(MLJBase.classes(v2), probs2)
+    @test_throws ArgumentError MLJModels._predict_threshold(unf_arr2, (0.7, 0.3))
+    @test MLJModels._predict_threshold(unf_arr2, (0.2, 0.5, 0.3)) == [v2[4], v2[2], v2[1]]
+    @test MLJModels._predict_threshold(unf_arr2, [0.3, 0.2, 0.5]) == [v2[2], v2[2], v2[1]]
+    @test MLJModels._predict_threshold(unf_arr2, (0.4, 0.4, 0.2)) == [v2[4], v2[2], v2[4]]
+    @test MLJModels._predict_threshold(unf_arr2, [0.2, 0.5, 0.3]) == [v2[4], v2[2], v2[1]]
+end
+
+end
+true

--- a/test/builtins/ThresholdPredictors.jl
+++ b/test/builtins/ThresholdPredictors.jl
@@ -12,7 +12,7 @@ import MLJBase
 
     model = BinaryThresholdPredictor()
     # Check when predictions contain a single class
-    f, _, _ = MLJBase.fit(model, X, y1, X)
+    f, _, _ = MLJBase.fit(model, 1, X, y1)
     @test_logs((:warn, r"Predicted `AbstractVector{<:UnivariateFinite}`"),
         MLJBase.predict(model, f, X))
     @test MLJBase.predict(model, f, X) == MLJBase.predict_mode(model.wrapped_model, f[1], X)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,9 @@ end
     @testset "Transformers" begin
         @test include("builtins/Transformers.jl")
     end
+    @testset "ThresholdPredictors" begin
+        @test include("builtins/ThresholdPredictors.jl")
+    end
 end
 
 @testset "MultivariateStats  " begin


### PR DESCRIPTION
Following discussion with @vollmersj on slack, this PR adds `BinaryThresholdPredictor` model. Which is essentially a model wrapping a `Binary` `Probabilistic` classifier and predicts a `Deterministic` response from the `AbstractArray{<:UnivariateFinite, 1}` predictions made from the wrapped model using a specified `threshold`.
This much like MLR's [tuneThreshold](https://mlr.mlr-org.com/reference/tuneThreshold.html) allows users to tune probability threshold by wrapping the `BinaryThresholdPredictor` model in a `TunedModel` wrapper.
