### PR TITLE
Refactor of @load

### DIFF
--- a/src/MLJModels.jl
+++ b/src/MLJModels.jl
@@ -17,7 +17,7 @@ import Distributions
 export @update, check_registry
 
 # from loading.jl:
-export load, @load, info
+export load, @load, info, @loadcode
 
 # from model_search:
 export models, localmodels

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -69,6 +69,13 @@ macro load(name_ex, kw_exs...)
     esc(program)
 end
 
+macro loadcode(name_ex, kw_exs...)
+    program, instance_ex = _load(__module__, name_ex, kw_exs...)
+    esc(program)
+end
+
+
+
 # builds the program to be evaluated by the @load macro:
 function _load(modl, name_ex, kw_exs...)
 
@@ -171,7 +178,8 @@ function _load(modl, name_ex, kw_exs...)
     return program, instance_ex
 end
 
-## DEPRECATED
+
+## NO LONGER SUPPORTED
 
 _deperror() = error(
     "The `load` function is no longer supported. "*

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -4,57 +4,39 @@ module TestLoading
 using Test
 using MLJModels
 
-@testset "`load` function" begin
 
-    load("RidgeRegressor",
-         pkg="MultivariateStats",
-         modl=TestLoading,
-         verbosity=1)
+@load RidgeRegressor pkg=MultivariateStats verbosity=0
 
-    @test isdefined(TestLoading, :RidgeRegressor)
-    @test MLJModels.info("RidgeRegressor", pkg="MultivariateStats") in
+@test isdefined(TestLoading, :RidgeRegressor)
+@test MLJModels.info("RidgeRegressor", pkg="MultivariateStats") in
     localmodels(modl=TestLoading)
 
-    # load the same model again:
-    @test_logs (:info, r"Model code") begin
-        load("RidgeRegressor",
-             pkg="MultivariateStats",
-             modl=TestLoading,
-             verbosity=1)
-    end
+# if we load the same model again:
+program, _ = @test_logs((:info, r"For silent"),
+           (:info, r"Model code"),
+           MLJModels._load(TestLoading,
+                           :(RidgeRegressor),
+                           :(pkg=MultivariateStats)))
+eval(program)
 
-    @test !isdefined(TestLoading, :RidgeRegressor2)
+@test !isdefined(TestLoading, :RidgeRegressor2)
 
-    # load the same model again, with a different binding:
-    load("RidgeRegressor",
-         pkg="MultivariateStats",
-         modl=TestLoading,
-         verbosity=1,
-         name="Foo")
+# load the same model again, with a different binding:
+@load RidgeRegressor pkg=MultivariateStats name=Foo
 
-    @test Foo() == RidgeRegressor()
+@test Foo() == RidgeRegressor()
 
-    # TODO: re-instate when only julia ^1.2 is supported. 
+# try to use the name of an existing object for new type name
+program, _ = MLJModels._load(TestLoading,
+                :(DecisionTreeClassifier),
+                :(pkg=DecisionTree),
+                :(name=RidgeRegressor))
 
-    # # load a model with same name from different package: @test_logs
-    # (:warn, r"New model type") begin load("RidgeRegressor",
-    # pkg="MLJLinearModels", modl=TestLoading, verbosity=0) end
+@test_throws Exception eval(program)
 
-    # @test typeof(RidgeRegressor2()) != typeof(RidgeRegressor())
+@test_throws Exception load("model", pkg = "pkg")
+@test_throws Exception load(models()[1])
 
-    # try to use the name of an existing object for new type name
-    @test_throws Exception load("DecisionTreeClassifier",
-                                pkg="DecisionTree",
-                                modl=TestLoading,
-                                verbosity=0,
-                                name="RidgeRegressor")
-end
-
-@testset "@load macro" begin
-    @load PCA
-    @test isdefined(TestLoading, :PCA)
-    @test_throws(ArgumentError, load("RidgeRegressor", modl=TestLoading))
-end
 
 end # module
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -4,6 +4,7 @@ module TestLoading
 using Test
 using MLJModels
 
+@loadcode RandomForestClassifier pkg=DecisionTree verbosity=0
 
 @load RidgeRegressor pkg=MultivariateStats verbosity=0
 
@@ -30,7 +31,7 @@ eval(program)
 program, _ = MLJModels._load(TestLoading,
                 :(DecisionTreeClassifier),
                 :(pkg=DecisionTree),
-                :(name=RidgeRegressor))
+                             :(name=RidgeRegressor))
 
 @test_throws Exception eval(program)
 


### PR DESCRIPTION
Addresses https://github.com/alan-turing-institute/MLJ.jl/issues/693 . 

- The intended behaviour of `@load` is not changed by this PR with this exception: By default `verbosity=1`, so that newcomers understand what the macros is doing. I think this has been a source of confusion a number of times.

```julia
julia> @load AdaBoostStumpClassifier
[ Info: For silent loading, specify `verbosity=0`. 
import MLJDecisionTreeInterface ✔
const AdaBoostStumpClassifier = MLJDecisionTreeInterface.AdaBoostStumpClassifier ✔
AdaBoostStumpClassifier(
    n_iter = 10,
    pdf_smoothing = 0.0) @036
```

- to load code without returning an instance of the new model type, there is a new macro `@loadcode`

- Support for the `load` function is removed.  Instead, for explicit importing of model types without a macro, the user may extract the appropriate load path using the `load_path` function, a model trait now overloaded to work on strings and model registry entries:

```julia
julia> load_path("PCA")
"MLJMultivariateStatsInterface.PCA"

julia> load_path("LinearRegressor", pkg="GLM")
"MLJModels.GLM_.LinearRegressor"

julia> load_path(models()[1])
"MLJScikitLearnInterface.ARDRegressor"
```
TODO:

- [x] Test `@load` works from within modules and packages (provided interface is not Requires-loaded - a known issue, see https://github.com/alan-turing-institute/MLJModels.jl/issues/22)
