### PR TITLE
Add the optional `scope` keyword argument to the `@load` macro

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -38,6 +38,9 @@ program, _ = MLJModels._load(TestLoading,
 @test_throws Exception load("model", pkg = "pkg")
 @test_throws Exception load(models()[1])
 
+@testset "scope=:local inside a @testset" begin
+    @load RidgeRegressor pkg=MultivariateStats verbosity=0 scope=:local
+end
 
 end # module
 


### PR DESCRIPTION
Fixes https://github.com/alan-turing-institute/MLJ.jl/issues/715

This pull request adds the optional `scope` keyword argument to the `@load` macro. The default value is `scope=:global`.

If the user sets `scope=:local`, we omit the `const` keyword. This allows users to use `@load` in local scope, where the `const` keyword is not allowed.

Before this PR:
```julia
julia> using MLJModels

julia> using Test

julia> @testset begin
           @load DecisionTreeClassifier
       end
[ Info: For silent loading, specify `verbosity=0`.
ERROR: syntax: unsupported `const` declaration on local variable around ~/.julia/dev/MLJModels.jl/src/loading.jl:82
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
```

After this PR:
```julia
julia> using MLJModels

julia> using Test

julia> @testset begin
           @load DecisionTreeClassifier scope=:local
       end
[ Info: For silent loading, specify `verbosity=0`.
import MLJDecisionTreeInterface ✔
DecisionTreeClassifier = MLJDecisionTreeInterface.DecisionTreeClassifier ✔
DecisionTreeClassifier() ✔
Test Summary: |
test set      | No tests
Test.DefaultTestSet("test set", Any[], 0, false, false)
```
