### PR TITLE
Add the optional `install_pkgs` keyword argument to the `@load` macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,9 +44,10 @@ LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
 MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
 MLJMultivariateStatsInterface = "1b6a4a23-ba22-4f51-9698-8599985d3728"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DecisionTree", "Distances", "GLM", "LIBSVM", "MLJDecisionTreeInterface", "MLJMultivariateStatsInterface", "NearestNeighbors", "ScientificTypes", "StableRNGs", "Test"]
+test = ["DecisionTree", "Distances", "GLM", "LIBSVM", "MLJDecisionTreeInterface", "MLJMultivariateStatsInterface", "NearestNeighbors", "Pkg", "ScientificTypes", "StableRNGs", "Test"]

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -42,6 +42,11 @@ program, _ = MLJModels._load(TestLoading,
     @load RidgeRegressor pkg=MultivariateStats verbosity=0 scope=:local
 end
 
+@testset "install_pkgs=true" begin
+    @load KMeans pkg=Clustering verbosity=0 scope=:local install_pkgs=true
+    @load KMeans pkg=Clustering verbosity=0 scope=:local install_pkgs=true
+end
+
 end # module
 
 true


### PR DESCRIPTION
This pull request adds the optional `install_pkgs` keyword argument to the `@load` macro.

If `install_pkgs` is `true`, then any necessary packages will automatically be installed.

The default value is `install_pkgs=false`.

Example usage:
```julia
julia> using MLJModels

julia> @load NeuralNetworkClassifier install_pkgs=true
```

## Motivation

@juliohm has brought up that installing all of the necessary packages is one of the pain points for Julia beginners when they first start out using MLJ.

Therefore, we can tell these beginner users to use `install_pkgs=true`, and then the necessary packages will automatically be installed for them.