### PR TITLE
Check onehotencoding category level

### DIFF
--- a/src/builtins/Transformers.jl
+++ b/src/builtins/Transformers.jl
@@ -1152,8 +1152,7 @@ function MMI.fit(transformer::OneHotEncoder, verbosity::Int, X)
 
     fitresult = OneHotEncoderResult(collect(all_features),
                                     ref_name_pairs_given_feature,
-                                    known_levels
-                                    )
+                                    known_levels)
 
     # get new feature names
     d = ref_name_pairs_given_feature

--- a/test/builtins/Transformers.jl
+++ b/test/builtins/Transformers.jl
@@ -421,6 +421,9 @@ end
     t = OneHotEncoder(features=[:name,], ignore=true)
     f, = MLJBase.fit(t, 0, X)
     Xt = MLJBase.transform(t, f, X)
+    @test MLJBase.schema(Xt).names == (:name, :height, :favourite_number__5,
+                               :favourite_number__7, :favourite_number__10,
+                               :age)
 
     # test exclusion of ordered factors:
     t  = OneHotEncoder(ordered_factor=false)
@@ -442,6 +445,19 @@ end
          age        = [23, 23, 14, 23],
          gender     = categorical(['M', 'M', 'F', 'M']))
     @test_throws Exception MLJBase.transform(t, f, X)
+    
+    # test to throw exception when category level mismatch is found
+    X = (name   = categorical(["Ben", "John", "Mary", "John"], ordered=true),
+         height = [1.85, 1.67, 1.5, 1.67],
+         favourite_number = categorical([7, 5, 10, 5]),
+         age    = [23, 23, 14, 23])
+    Xmiss = (name   = categorical(["John", "Mary", "John"], ordered=true),
+             height = X.height,
+             favourite_number = X.favourite_number,
+             age    = X.age)
+    t  = OneHotEncoder()
+    f, = MLJBase.fit(t, 0, X)
+    @test_throws Exception MLJBase.transform(t, f, Xmiss)
 
     infos = MLJBase.info_dict(t)
 


### PR DESCRIPTION
This PR tries to add a check for category level mismatch in OneHotEncoder.

As pointed out in #306, a transform function for OneHotEncoder returns wrong values when the transforming features have different category levels from fitting time.

This PR checks whether each transforming feature has the same category levels as the fitted version in the transform function and throws an exception when a mismatch is detected.

## Changes
1. Add a dictionary into the OneHotEncoderResult struct and logic to store original category levels in it.
2. Add a check whether transforming features have the same levels as the stored levels.
3. Add a test case to confirm that an exception is thrown if a mismatch is detected.
4. Add a test case for the `ignore` option of OneHotEncoder because I found it missing in the current version.

## Example
This is an example of behavior after the fix.

```julia
using MLJ

X = (x = coerce(["black", "white", "white", "black"], Multiclass),)
Xproduction = (x = coerce(["white", "white"], Multiclass),)

model = OneHotEncoder()
mach = machine(model, X) |> fit!

julia> transform(mach, selectrows(X, 2:3))
(x__black = [0.0, 0.0],
 x__white = [1.0, 1.0],)

julia> transform(mach, Xproduction)
ERROR: Found category level mismatch in feature `x`. Consider using `levels!` to ensure fitted and transforming features have the same category levels.

julia> levels!(Xproduction.x, levels(X.x))
2-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
 "white"
 "white"
 
julia> transform(mach, Xproduction)
(x__black = [0.0, 0.0],
 x__white = [1.0, 1.0],)
```

