### PR TITLE
Bump CategoricalArrays.jl version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModels"
 uuid = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.14.4"
+version = "0.14.5"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
@@ -24,7 +24,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-CategoricalArrays = "^0.8,^0.9"
+CategoricalArrays = "^0.8,^0.9,^0.10"
 Distances = "^0.9,^0.10"
 Distributions = "^0.22,^0.23,^0.24"
 MLJBase = "^0.17.1, ^0.18"


### PR DESCRIPTION
Appreciate if you can review, merge and release. This is blocking downstream packages from having the latest CategoricalArrays.jl